### PR TITLE
Avoid crash in example supertasks (DM-8004)

### DIFF
--- a/python/lsst/pipe/supertask/examples/ExampleStats.py
+++ b/python/lsst/pipe/supertask/examples/ExampleStats.py
@@ -95,6 +95,13 @@ class ExampleMeanTask(SuperTask):
         parser.add_id_argument("--id", "raw", help="data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
         return parser
 
+    def _get_config_name(self):
+        """!Get the name prefix for the task config's dataset type, or None to prevent persisting the config
+
+        This override returns None to avoid persisting metadata for this trivial task.
+        """
+        return None
+
 
 @super_task.wrapclass(super_task.wraprun)
 class ExampleStdTask(SuperTask):
@@ -135,3 +142,10 @@ class ExampleStdTask(SuperTask):
         parser = pipeBase.InputOnlyArgumentParser(name=cls._default_name)
         parser.add_id_argument("--id", "raw", help="data IDs, e.g. --id visit=12345 ccd=1,2^0,3")
         return parser
+
+    def _get_config_name(self):
+        """!Get the name prefix for the task config's dataset type, or None to prevent persisting the config
+
+        This override returns None to avoid persisting metadata for this trivial task.
+        """
+        return None

--- a/python/lsst/pipe/supertask/examples/NewExampleCmdLineTask.py
+++ b/python/lsst/pipe/supertask/examples/NewExampleCmdLineTask.py
@@ -145,16 +145,16 @@ class NewExampleCmdLineTask(pipeSuper.SuperTask):
         # return the pipe_base Struct that is returned by self.stats.run
         return self.stats.run(maskedImage)
 
-    def _getConfigName(self):
+    def _get_config_name(self):
         """!Get the name prefix for the task config's dataset type, or None to prevent persisting the config
 
         This override returns None to avoid persisting metadata for this trivial task.
 
         However, if the method returns a name, then the full name of the dataset type will be <name>_config.
-        The default CmdLineTask._getConfigName returns _DefaultName,
+        The default SuperTask._get_config_name returns _DefaultName,
         which for this task would result in a dataset name of "exampleTask_config".
 
-        Normally you can use the default CmdLineTask._getConfigName, but here are two reasons
+        Normally you can use the default SuperTask._get_config_name, but here are two reasons
         why you might want to override it:
         - If you do not want your task to write its config, then have the override return None.
           That is done for this example task, because I didn't want to clutter up the
@@ -164,20 +164,5 @@ class NewExampleCmdLineTask(pipeSuper.SuperTask):
           \ref lsst.skymap.SkyMap "sky map" (sky pixelization for a coadd)
           for any of several different types of coadd, such as deep or goodSeeing.
           As such, the name of the persisted config must include the coadd type in order to be unique.
-
-        Normally if you override _getConfigName then you override _getMetadataName to match.
-        """
-        return None
-
-    def _getMetadataName(self):
-        """!Get the name prefix for the task metadata's dataset type, or None to prevent persisting metadata
-
-        This override returns None to avoid persisting metadata for this trivial task.
-
-        However, if the method returns a name, then the full name of the dataset type will be <name>_metadata.
-        The default CmdLineTask._getConfigName returns _DefaultName,
-        which for this task would result in a dataset name of "exampleTask_metadata".
-
-        See the description of _getConfigName for reasons to override this method.
         """
         return None

--- a/python/lsst/pipe/supertask/examples/test1task.py
+++ b/python/lsst/pipe/supertask/examples/test1task.py
@@ -54,5 +54,12 @@ class Test1Task(SuperTask):
 
         return self.output
 
+    def _get_config_name(self):
+        """!Get the name prefix for the task config's dataset type, or None to prevent persisting the config
+
+        This override returns None to avoid persisting metadata for this trivial task.
+        """
+        return None
+
     def __str__(self):
         return str(self.__class__.__name__)+' named : '+self.name

--- a/python/lsst/pipe/supertask/examples/test2task.py
+++ b/python/lsst/pipe/supertask/examples/test2task.py
@@ -69,5 +69,12 @@ class Test2Task(SuperTask):
             str2='value 2')
         return self.output
 
+    def _get_config_name(self):
+        """!Get the name prefix for the task config's dataset type, or None to prevent persisting the config
+
+        This override returns None to avoid persisting metadata for this trivial task.
+        """
+        return None
+
     def __str__(self):
         return str(self.__class__.__name__)+' named : '+self.name


### PR DESCRIPTION
Example supertasks need to define _get_config_name() method returning
None to avoid crash. Removed NewExampleCmdLineTask._getMetadataName()
which is not used by anything.