### PR TITLE
Initial implementation of resource API and few other supertask methods (DM-8283).

### DIFF
--- a/python/lsst/pipe/supertask/__init__.py
+++ b/python/lsst/pipe/supertask/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 from .activator import *
 from .super_task import *
+from .resource_config import *

--- a/python/lsst/pipe/supertask/resource_config.py
+++ b/python/lsst/pipe/supertask/resource_config.py
@@ -1,0 +1,51 @@
+"""
+Module defining ResourceConfig class and related methods.
+"""
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+import lsst.pex.config as pexConfig
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+class ResourceConfig(pexConfig.Config):
+    """Configuration for resource requirements.
+
+    This configuration class will be used by some activators to estimate
+    resource use by pipeline. Additionally some tasks could use it to adjust
+    their resource use (e.g. reduce the number of threads).
+
+    For some resources their limit can be estimated by corresponding task,
+    in that case task could set the field value. For many fields defined in
+    this class their associated resource use by a task will depend on the
+    size of the data and is not known in advance. For these resources their
+    value will be configured through overrides based on some external
+    estimates.
+    """
+    min_memory_MB = pexConfig.Field(dtype=int, default=None, optional=True,
+                                    doc="Minimal memory needed by task, can be None if estimate is unknown.")
+    min_num_cores = pexConfig.Field(dtype=int, default=1,
+                                    doc="Minimal number of cores needed by task.")
+
+class ConfigWithResource(pexConfig.Config):
+    """Configuration class which includes resource requirements.
+
+    This configuration class can be used as a base class (instead of regular
+    `lsst.pex.config.COnfig`) for configurations of the tasks that need
+    to declare their resource use. Alternatively any task configuration
+    class can include "resources" field just like this class does. The name
+    "resources" is pre-defined field known to activators and used to access
+    per-task resource configuration.
+    """
+    resources = pexConfig.ConfigField(dtype=ResourceConfig, doc=ResourceConfig.__doc__)

--- a/python/lsst/pipe/supertask/resource_config.py
+++ b/python/lsst/pipe/supertask/resource_config.py
@@ -28,7 +28,7 @@ class ResourceConfig(pexConfig.Config):
 
     For some resources their limit can be estimated by corresponding task,
     in that case task could set the field value. For many fields defined in
-    this class their associated resource use by a task will depend on the
+    this class their associated resource used by a task will depend on the
     size of the data and is not known in advance. For these resources their
     value will be configured through overrides based on some external
     estimates.
@@ -42,7 +42,7 @@ class ConfigWithResource(pexConfig.Config):
     """Configuration class which includes resource requirements.
 
     This configuration class can be used as a base class (instead of regular
-    `lsst.pex.config.COnfig`) for configurations of the tasks that need
+    `lsst.pex.config.Config`) for configurations of the tasks that need
     to declare their resource use. Alternatively any task configuration
     class can include "resources" field just like this class does. The name
     "resources" is pre-defined field known to activators and used to access

--- a/python/lsst/pipe/supertask/super_task.py
+++ b/python/lsst/pipe/supertask/super_task.py
@@ -236,7 +236,7 @@ class SuperTask(Task):
 
         Returns a tuple containing two elements - set (iterable) of input
         dataset types and set (iterable) of output dataset types. For leaf
-        tasks these two sets will not overlap. For parent task these sets
+        tasks these two sets will not overlap. For parent tasks these sets
         will include a union of corresponding sets of their sub-tasks unless
         `intermediates` is set to False. If `intermediates` is False then
         dataset types appearing in output of some sub-task will be removed

--- a/python/lsst/pipe/supertask/super_task.py
+++ b/python/lsst/pipe/supertask/super_task.py
@@ -223,6 +223,14 @@ class SuperTask(Task):
                 self.log.info("Writing schema %s" % schema_dataset)
                 butler.put(catalog, schema_dataset)
 
+    def get_resource_config(self):
+        """Return resource configuration for this task.
+
+        Returns object of type `resource_config.ResourceConfig`or None if resource configuration
+        is not defined for this task.
+        """
+        return getattr(self.config, "resources", None)
+
     def _get_config_name(self):
         """!Return the name of the config dataset type, or None if config is not to be persisted
         @note The name may depend on the config; that is why this is not a class method.

--- a/tests/testResourceConfig.py
+++ b/tests/testResourceConfig.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Simple unit test for ResourceConfig.
+"""
+#
+# LSST Data Management System
+# Copyright 2016 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+
+import lsst.utils.tests
+import lsst.pex.config as pexConfig
+from lsst.pipe import supertask
+
+
+class NoResourceTask(supertask.SuperTask):
+    _DefaultName = "no_resource_task"
+    ConfigClass = pexConfig.Config
+
+
+class OneConfig(supertask.ConfigWithResource):
+    pass
+
+
+class OneTask(supertask.SuperTask):
+    _DefaultName = "one_task"
+    ConfigClass = OneConfig
+
+
+class TwoConfig(pexConfig.Config):
+    resources = pexConfig.ConfigField(dtype=supertask.ResourceConfig, doc=supertask.ResourceConfig.__doc__)
+
+
+class TwoTask(supertask.SuperTask):
+    _DefaultName = "two_task"
+    ConfigClass = OneConfig
+
+
+class ThreeConfig(supertask.ConfigWithResource):
+
+    def setDefaults(self):
+        self.resources.min_memory_MB = 1024
+        self.resources.min_num_cores = 32
+
+
+class ThreeTask(supertask.SuperTask):
+    _DefaultName = "three_task"
+    ConfigClass = ThreeConfig
+
+
+class TaskTestCase(unittest.TestCase):
+    """A test case for Task
+    """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testNoResource(self):
+        """Test for a task without resource config
+        """
+        task = NoResourceTask()
+        res_config = task.get_resource_config()
+        self.assertIs(res_config, None)
+
+    def testOneResource(self):
+        """Test for a task with resource config
+        """
+        task = OneTask()
+        res_config = task.get_resource_config()
+        self.assertIsNot(res_config, None)
+        self.assertIs(res_config.min_memory_MB, None)
+        self.assertEqual(res_config.min_num_cores, 1)
+
+    def testTwoResource(self):
+        """Test for a task with resource config
+        """
+        task = TwoTask()
+        res_config = task.get_resource_config()
+        self.assertIsNot(res_config, None)
+        self.assertIs(res_config.min_memory_MB, None)
+        self.assertEqual(res_config.min_num_cores, 1)
+
+    def testThreeResource(self):
+        """Test for a task with resource config and special defaults
+        """
+        task = ThreeTask()
+        res_config = task.get_resource_config()
+        self.assertIsNot(res_config, None)
+        self.assertEqual(res_config.min_memory_MB, 1024)
+        self.assertEqual(res_config.min_num_cores, 32)
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testSuperTaskGetDataTypes.py
+++ b/tests/testSuperTaskGetDataTypes.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""Unit test for SuperTask.get_data_types() method.
+"""
+#
+# LSST Data Management System
+# Copyright 2016 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+import unittest
+
+import lsst.utils.tests
+import lsst.pex.config as pexConfig
+from lsst.pipe import supertask
+
+class LeafTaskBroken(supertask.SuperTask):
+    """Does not implement get_data_types(), will throw exception"""
+    _DefaultName = "leaf_task_broken"
+    ConfigClass = pexConfig.Config
+
+class LeafTaskIsr(supertask.SuperTask):
+    _DefaultName = "leaf_task_isr"
+    ConfigClass = pexConfig.Config
+
+    def get_data_types(self, intermediates=False):
+        return (['raw', 'raw_too'], ['isr'])
+
+class LeafTaskCal(supertask.SuperTask):
+    _DefaultName = "leaf_task_cal"
+    ConfigClass = pexConfig.Config
+
+    def get_data_types(self, intermediates=False):
+        return (['isr', 'some_db'], ['calexp', 'calexp_db_extra'])
+
+class IsrCalexpConfig(pexConfig.Config):
+    isr = LeafTaskIsr.makeField("leaf task 1")
+    cal = LeafTaskCal.makeField("leaf task 2")
+
+class IsrCalexpTask(supertask.SuperTask):
+    _DefaultName = "parent_subtask"
+    ConfigClass = IsrCalexpConfig
+
+    def __init__(self, **keyArgs):
+        super(IsrCalexpTask, self).__init__(**keyArgs)
+        self.makeSubtask("isr")
+        self.makeSubtask("cal")
+
+
+class GetDataTypesTestCase(unittest.TestCase):
+    """A test case for SuperTask.get_data_types method
+    """
+
+    def testBrokenLeaf(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = LeafTaskBroken()
+        with self.assertRaises(NotImplementedError):
+            pipeline.get_data_types()
+        with self.assertRaises(NotImplementedError):
+            pipeline.get_data_types(True)
+
+    def testIsr(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = LeafTaskIsr()
+        input, output = pipeline.get_data_types()
+        self.assertEqual(set(input), set(['raw', 'raw_too']))
+        self.assertEqual(set(output), set(['isr']))
+        input, output = pipeline.get_data_types(True)
+        self.assertEqual(set(input), set(['raw', 'raw_too']))
+        self.assertEqual(set(output), set(['isr']))
+
+    def testCal(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = LeafTaskCal()
+        input, output = pipeline.get_data_types()
+        self.assertEqual(set(input), set(['isr', 'some_db']))
+        self.assertEqual(set(output), set(['calexp', 'calexp_db_extra']))
+        input, output = pipeline.get_data_types(True)
+        self.assertEqual(set(input), set(['isr', 'some_db']))
+        self.assertEqual(set(output), set(['calexp', 'calexp_db_extra']))
+
+    def testIsrCal(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = IsrCalexpTask()
+        input, output = pipeline.get_data_types()
+        self.assertEqual(set(input), set(['raw', 'raw_too', 'some_db']))
+        self.assertEqual(set(output), set(['isr', 'calexp', 'calexp_db_extra']))
+        input, output = pipeline.get_data_types(True)
+        self.assertEqual(set(input), set(['raw', 'raw_too', 'some_db', 'isr']))
+        self.assertEqual(set(output), set(['isr', 'calexp', 'calexp_db_extra']))
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testSuperTaskGetSubTasks.py
+++ b/tests/testSuperTaskGetSubTasks.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+"""Unit test for SuperTask.get_sub_tasks() method.
+"""
+#
+# LSST Data Management System
+# Copyright 2016 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+import unittest
+
+import lsst.utils.tests
+import lsst.pex.config as pexConfig
+from lsst.pipe import supertask
+
+
+class LeafTask(supertask.SuperTask):
+    _DefaultName = "leaf_task"
+    ConfigClass = pexConfig.Config
+
+class ParentSubConfig(pexConfig.Config):
+    leaf1 = LeafTask.makeField("leaf task 1")
+    leaf2 = LeafTask.makeField("leaf task 2")
+
+class ParentSubTask(supertask.SuperTask):
+    _DefaultName = "parent_subtask"
+    ConfigClass = ParentSubConfig
+
+    def __init__(self, **keyArgs):
+        super(ParentSubTask, self).__init__(**keyArgs)
+        self.makeSubtask("leaf1")
+        self.makeSubtask("leaf2")
+
+class ParentConfig(pexConfig.Config):
+    subtask1 = ParentSubTask.makeField("sub task 1")
+    subtask2 = ParentSubTask.makeField("sub task 2")
+
+class ParentTask(supertask.SuperTask):
+    _DefaultName = "parent_task"
+    ConfigClass = ParentConfig
+
+    def __init__(self, **keyArgs):
+        super(ParentTask, self).__init__(**keyArgs)
+        self.makeSubtask("subtask1")
+        self.makeSubtask("subtask2")
+
+class GetSubTasksTestCase(unittest.TestCase):
+    """A test case for SuperTask.get_sub_tasks method
+    """
+
+    all_names = ['parent_task',
+                 'parent_task.subtask1',
+                 'parent_task.subtask2',
+                 'parent_task.subtask1.leaf1',
+                 'parent_task.subtask1.leaf2',
+                 'parent_task.subtask2.leaf1',
+                 'parent_task.subtask2.leaf2']
+    all_leaves = ['parent_task.subtask1.leaf1',
+                  'parent_task.subtask1.leaf2',
+                  'parent_task.subtask2.leaf1',
+                  'parent_task.subtask2.leaf2']
+
+    def _check_names(self, tasks, names):
+        task_names = [task.getFullName() for task in tasks]
+        self.assertEqual(set(task_names), set(names))
+
+    def testAllNames(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = ParentTask()
+        for task in (pipeline, pipeline.subtask1, pipeline.subtask2,
+                     pipeline.subtask1.leaf1):
+            tasks = task.get_sub_tasks()
+            self._check_names(tasks, self.all_names)
+
+    def testLeafs(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = ParentTask()
+        for task in (pipeline, pipeline.subtask1, pipeline.subtask2,
+                     pipeline.subtask1.leaf1):
+            tasks = task.get_sub_tasks(leaf_only=True)
+            self._check_names(tasks, self.all_leaves)
+
+    def testSubTasks(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = ParentTask()
+
+        tasks = pipeline.get_sub_tasks(whole_pipeline=False)
+        self._check_names(tasks, self.all_names)
+
+        tasks = pipeline.subtask1.get_sub_tasks(whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask1',
+                                  'parent_task.subtask1.leaf1',
+                                  'parent_task.subtask1.leaf2'])
+
+        tasks = pipeline.subtask2.get_sub_tasks(whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask2',
+                                  'parent_task.subtask2.leaf1',
+                                  'parent_task.subtask2.leaf2'])
+
+        tasks = pipeline.subtask2.leaf1.get_sub_tasks(whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask2.leaf1'])
+
+        tasks = pipeline.subtask1.leaf2.get_sub_tasks(whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask1.leaf2'])
+
+    def testSubLeaves(self):
+        """Testing that get_sub_tasks() without options returns all tasks
+        """
+        pipeline = ParentTask()
+
+        tasks = pipeline.get_sub_tasks(leaf_only=True, whole_pipeline=False)
+        self._check_names(tasks, self.all_leaves)
+
+        tasks = pipeline.subtask1.get_sub_tasks(leaf_only=True, whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask1.leaf1',
+                                  'parent_task.subtask1.leaf2'])
+
+        tasks = pipeline.subtask2.get_sub_tasks(leaf_only=True, whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask2.leaf1',
+                                  'parent_task.subtask2.leaf2'])
+
+        tasks = pipeline.subtask2.leaf1.get_sub_tasks(leaf_only=True, whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask2.leaf1'])
+
+        tasks = pipeline.subtask1.leaf2.get_sub_tasks(leaf_only=True, whole_pipeline=False)
+        self._check_names(tasks, ['parent_task.subtask1.leaf2'])
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Added ResourceConfig class which contains smallest set of fields describing resource limits used by task. The set will be expanded later as we know more about it (and if this design is accepted). Added new method to SuperTask to return the instance of that class corresponding to the task. Added unit test for these new items.

Add SuperTask.get_sub_tasks() method. This new method would be useful for activator in combination with the new resource API. Some activators will likely need a way to iterate over all leaf-node tasks, this new method implements that as on of the options.

Add SuperTask.get_data_types() method. New method returns sets of input and output data types for a task. Default implementation should work for a regular parent tasks, leaf tasks will need to override it (though we may have a configurable way to provide this sort of info in the future). Unit test for this new method is added too.
