### PR TITLE
Fix for python3 compatibility (DM-9352)

### DIFF
--- a/python/lsst/pipe/supertask/parser.py
+++ b/python/lsst/pipe/supertask/parser.py
@@ -224,6 +224,9 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
                                        description=("Valid commands, use `<command> --help' to get "
                                                     "more info about each command:"),
                                        prog=parser.prog)
+    # Python3 workaround, see http://bugs.python.org/issue9253#msg186387
+    # The issue was fixed in Python 3.6, workaround is not need starting with that version
+    subparsers.required = True
 
     # list sub-command
     subparser = subparsers.add_parser("list",

--- a/tests/testCmdLineParser.py
+++ b/tests/testCmdLineParser.py
@@ -133,7 +133,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             list
             """.split())
         list_options = ['show', 'show_headers', 'subparser']
-        self.assertItemsEqual(list(vars(args).keys()), global_options + list_options)
+        self.assertEqual(set(vars(args).keys()), set(global_options + list_options))
         self.assertEqual(args.subcommand, 'list')
 
         args = parser.parse_args(
@@ -141,7 +141,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             show cmd
             """.split())
         show_options = ['taskname', 'show', 'config_overrides', 'subparser', 'do_help']
-        self.assertItemsEqual(list(vars(args).keys()), global_options + show_options)
+        self.assertEqual(set(vars(args).keys()), set(global_options + show_options))
         self.assertEqual(args.subcommand, 'show')
 
         args = parser.parse_args(
@@ -149,7 +149,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             run taskname
             """.split())
         run_options = ['taskname', 'show', 'config_overrides', 'subparser', 'do_help']
-        self.assertItemsEqual(list(vars(args).keys()), global_options + run_options)
+        self.assertEqual(set(vars(args).keys()), set(global_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 
         # default options


### PR DESCRIPTION
Small fixes needed for argparse sub-command handling in py3 and for unit
test asserts which are different between py2 and py3.