### PR TITLE
DM-9329: Implement trivial parallelization of task execution

### DIFF
--- a/ups/pipe_supertask.table
+++ b/ups/pipe_supertask.table
@@ -1,5 +1,4 @@
 setupRequired(pipe_base)
-setupRequired(pipe_tasks)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
This works in exactly the same way as CmdLineTask concurrency by using
multiprocessing Pool to execute a copy of each task on a separate set
of data IDs.