### PR TITLE
Implement a bunch of missing features (DM-10839)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ target/
 .sconsign.dblite
 python/lsst/pipe/supertask/version.py
 ups/*.cfgc
-bin/cmdLineActivator
+bin/stac
 .idea/
+tests/.tests/

--- a/python/lsst/pipe/supertask/graph.py
+++ b/python/lsst/pipe/supertask/graph.py
@@ -1,0 +1,92 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Module defining execution graph classes and related methods.
+
+There could be different representations of the pipeline execution
+graph depending on the client needs. Presently this module contains
+graph implementation which is based on requirements of command-line
+environment. In the future we could add other implementations and
+methods to convert between those representations.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+# "exported" names
+__all__ = ["GraphOfTasks", "GraphTaskNodes"]
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+class GraphTaskNodes(object):
+    """GraphTaskNodes represents a bunch of nodes in an execution graph.
+
+    The node in SuperTask execution graph is represented by the SuperTask
+    and a single Quantum instance. One possible representation of the graph
+    is just a list of nodes without edges (edges can be deduced from nodes'
+    quantum inputs and outputs if needed). That representation can be
+    reduced to the list of SuperTasks and the corresponding list of Quanta.
+    This class defines this reduced representation.
+
+    Different frameworks may use different graph representation, this
+    representation was based mostly on requirements of command-line
+    "activator" which does not need explicit edges information.
+
+    Attributes
+    ----------
+    taskDef : `TaskDef`
+        Task defintion for this set of nodes.
+    quanta : `list` of `Quanta`
+        List of quanta corresponding to the task.
+    """
+    def __init__(self, taskDef, quanta):
+        self.taskDef = taskDef
+        self.quanta = quanta
+
+
+class GraphOfTasks(list):
+    """Graph is a sequence of GraphTaskNodes objects.
+
+    Typically the order of the tasks in the list will be the same as the
+    order of tasks in a pipeline (obviously depends on the code which
+    constructs graph).
+
+    Parameters
+    ----------
+    iterable : iterable of `GraphTaskNodes` instances, optional
+        Initial sequence of per-task nodes.
+    """
+    def __init__(self, iterable=None):
+        list.__init__(self, iterable or [])

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -36,10 +36,7 @@ __all__ = ['GraphBuilder']
 # Imports for other modules --
 #-----------------------------
 import lsst.log as lsstLog
-import lsst.obs.base.repodb.tests as repodbTest
-from lsst.pipe.base.task import TaskError
-from .taskFactory import TaskFactory
-from .taskLoader import (TaskLoader, KIND_SUPERTASK)
+from .graph import GraphTaskNodes, GraphOfTasks
 
 #----------------------------------
 # Local non-exported definitions --
@@ -84,8 +81,7 @@ class GraphBuilder(object):
 
         Returns
         -------
-        List of tuples (taskDef, quanta), `taskDef` is a `TaskDef` as present
-        in pipeline, and `quanta` is a sequence of `Quantum` instances.
+        `GraphOfTasks` instance.
 
         Raises
         ------
@@ -181,7 +177,7 @@ class GraphBuilder(object):
 
         Returns
         -------
-        Same value as `makeGraph()`.
+        `GraphOfTasks` instance.
 
         Raises
         ------
@@ -189,7 +185,7 @@ class GraphBuilder(object):
         """
         # get all quanta from each task, add it to the list and say
         # that list is a graph (one of the million possible representations)
-        graph = []
+        graph = GraphOfTasks()
         for task, taskDef in taskList:
 
             # call task to make its quanta
@@ -205,6 +201,6 @@ class GraphBuilder(object):
 #                     existing |= datasets
 
             # store in a graph
-            graph.append((taskDef, quanta))
+            graph.append(GraphTaskNodes(taskDef, quanta))
 
         return graph

--- a/python/lsst/pipe/supertask/parser.py
+++ b/python/lsst/pipe/supertask/parser.py
@@ -356,7 +356,7 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
                                       "found. If none of the options are specified then --super-tasks "
                                       "is used by default")
     subparser.set_defaults(subparser=subparser)
-    subparser.add_argument("-P", "--packages", dest="show", action="append_const", const="packages",
+    subparser.add_argument("-p", "--packages", dest="show", action="append_const", const="packages",
                            help="Shows list of the packages to search for tasks")
     subparser.add_argument("-m", "--modules", dest="show", action="append_const", const='modules',
                            help="Shows list of all modules existing in current list of packages")
@@ -382,13 +382,13 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
 
         subparser = subparsers.add_parser(subcommand,
                                           usage="`%(prog)s -t taskname [options] [-t taskname ...]' or "
-                                          "`%(prog)s -e path [options]'",
+                                          "`%(prog)s -p path [options]'",
                                           description=description,
                                           epilog=_EPILOG,
                                           formatter_class=RawDescriptionHelpFormatter)
         subparser.set_defaults(subparser=subparser)
         excl_group = subparser.add_mutually_exclusive_group(required=True)
-        excl_group.add_argument("-e", "--pipeline", dest="pipeline",
+        excl_group.add_argument("-p", "--pipeline", dest="pipeline",
                                 help="Location of a serialized pipeline definition (pickle file)."
                                 " This option cannot be used together with task names.",
                                 metavar="PATH")

--- a/python/lsst/pipe/supertask/quantum.py
+++ b/python/lsst/pipe/supertask/quantum.py
@@ -65,3 +65,12 @@ class Quantum(object):
         # check consistency
         if director and director not in inputs and director not in outputs:
             raise ValueError("Director dataset ({}) is not in inputs or outputs".format(director))
+
+    def __str__(self):
+        res = "Quantum(inputs={}, outputs={}".format(self.inputs, self.outputs)
+        if self.extras:
+            res += ", extras={}".format(self.extras)
+        if self.director:
+            res += ", director={}".format(self.director)
+        res += ")"
+        return res

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -240,6 +240,34 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertEqual(set(vars(args).keys()), set(global_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 
+    def testCmdLineList(self):
+
+        parser = parser_mod.makeParser(parser_class=_NoExitParser)
+
+        # check list subcommand with options
+        args = parser.parse_args("list".split())
+        self.assertIsNone(args.show)
+
+        args = parser.parse_args("list -p".split())
+        self.assertEqual(args.show, ["packages"])
+
+        args = parser.parse_args("list -m".split())
+        self.assertEqual(args.show, ["modules"])
+
+        args = parser.parse_args("list -t".split())
+        self.assertEqual(args.show, ["tasks"])
+
+        args = parser.parse_args("list -s".split())
+        self.assertEqual(args.show, ["super-tasks"])
+
+        args = parser.parse_args("list -s --super-tasks".split())
+        self.assertEqual(args.show, ["super-tasks", "super-tasks"])
+
+        args = parser.parse_args("list --packages --modules".split())
+        self.assertEqual(args.show, ["packages", "modules"])
+
+        args = parser.parse_args("list --super-tasks --tasks".split())
+        self.assertEqual(args.show, ["super-tasks", "tasks"])
 
     def testCmdLineTasks(self):
 
@@ -351,7 +379,8 @@ class CmdLineParserTestCase(unittest.TestCase):
 
         args = parser.parse_args(
             """
-            run -e pipeline
+            -p package
+            run -p pipeline
             --show config
             --show config=Task.*
             """.split())
@@ -360,17 +389,17 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertIsNone(args.config_overrides)
         self.assertEqual(args.pipeline, 'pipeline')
 
-        # -e and -t are exclusive
+        # -p and -t are exclusive
         with self.assertRaises(_Error):
-            parser.parse_args("run -e pipeline -t task".split())
+            parser.parse_args("run -p pipeline -t task".split())
 
-        # one of -e or -t is required
+        # one of -p or -t is required
         with self.assertRaises(_Error):
             parser.parse_args("run --show show".split())
 
-        # -e and -c cannot be used together (-c needs -t)
+        # -p and -c cannot be used together (-c needs -t)
         with self.assertRaises(_Error):
-            parser.parse_args("run -e pipeline -c config".split())
+            parser.parse_args("run -p pipeline -c config".split())
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Add support for specifying more than one task on command line and also
option for reading pipeline definition from pickle file (and also write
it to pickle file). Add a class representing execution graph, or at
least one representation of graph that is used by command-line tool.
Implemented a bunch of --show options.