### PR TITLE
Implement pipeline tools module and cli (DM-13449)

### DIFF
--- a/python/lsst/pipe/supertask/__init__.py
+++ b/python/lsst/pipe/supertask/__init__.py
@@ -11,7 +11,6 @@ except:
 from .config import *
 from .graphBuilder import *
 from .pipeline import *
-from .pipelineTools import *
 from .quantum import *
 from .resourceConfig import *
 from .superTask import *

--- a/python/lsst/pipe/supertask/__init__.py
+++ b/python/lsst/pipe/supertask/__init__.py
@@ -8,8 +8,10 @@ try:
 except:
     __version__ = "unknown"
 
+from .config import *
 from .graphBuilder import *
 from .pipeline import *
+from .pipelineTools import *
 from .quantum import *
 from .resourceConfig import *
 from .superTask import *

--- a/python/lsst/pipe/supertask/__init__.py
+++ b/python/lsst/pipe/supertask/__init__.py
@@ -11,6 +11,7 @@ except:
 from .config import *
 from .graphBuilder import *
 from .pipeline import *
+from .pipelineBuilder import *
 from .quantum import *
 from .resourceConfig import *
 from .superTask import *

--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017-2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/config.py
+++ b/python/lsst/pipe/supertask/config.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2018 LSST Corporation.
+# Copyright 2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/config.py
+++ b/python/lsst/pipe/supertask/config.py
@@ -1,0 +1,94 @@
+#
+# LSST Data Management System
+# Copyright 2018 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+"""
+Module defining config classes for SuperTask.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["QuantumConfig", "InputDatasetConfig", "OutputDatasetConfig",
+           "SuperTaskConfig"]
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+import lsst.pex.config as pexConfig
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+class QuantumConfig(pexConfig.Config):
+    """Configuration class which defines SuperTask quanta units.
+
+    In addition to a list of dataUnit names this also includes optional list of
+    SQL statements to be executed against Registry database. Exact meaning and
+    format of SQL will be determined at later point.
+    """
+    units = pexConfig.ListField(dtype=str,
+                                doc="list of DataUnits which define quantum")
+    sql = pexConfig.ListField(dtype=str,
+                              doc="sequence of SQL statements",
+                              optional=True)
+
+
+class InputDatasetConfig(pexConfig.Config):
+    """Configuration class which defines SuperTask input dataset.
+
+    Consists of DatasetType name and list of DataUnit names. SuperTasks
+    typically define one or more input datasets.
+    """
+    name = pexConfig.Field(dtype=str,
+                           doc="name of the DatasetType")
+    units = pexConfig.ListField(dtype=str,
+                                doc="list of DataUnits for this DatasetType")
+
+
+class OutputDatasetConfig(pexConfig.Config):
+    """Configuration class which defines SuperTask output dataset.
+
+    Consists of DatasetType name and list of DataUnit names. SuperTasks
+    typically define one or more output datasets.
+    """
+    name = pexConfig.Field(dtype=str,
+                           doc="name of the DatasetType")
+    units = pexConfig.ListField(dtype=str,
+                                doc="list of DataUnits fior this DatasetType")
+
+
+class SuperTaskConfig(pexConfig.Config):
+    """Base class for all SuperTask configurations.
+
+    This class defines fields that must be defined for every SuperTask.
+    It will be used as a base class for all SuperTask configurations instead
+    of `pex.config.Config`.
+    """
+    quantum = pexConfig.ConfigField(dtype=QuantumConfig,
+                                    doc="configuration for SuperTask quantum")

--- a/python/lsst/pipe/supertask/examples/NewExampleCmdLineTask.py
+++ b/python/lsst/pipe/supertask/examples/NewExampleCmdLineTask.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import
 #
 # LSST Data Management System
-# Copyright 2014 LSST Corporation.
+# Copyright 2014 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/graph.py
+++ b/python/lsst/pipe/supertask/graph.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/parser.py
+++ b/python/lsst/pipe/supertask/parser.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017-2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/parser.py
+++ b/python/lsst/pipe/supertask/parser.py
@@ -32,6 +32,7 @@ __all__ = ["makeParser"]
 #  Imports of standard modules --
 #--------------------------------
 from argparse import Action, ArgumentParser, RawDescriptionHelpFormatter
+from builtins import object
 import collections
 import itertools
 import re
@@ -46,10 +47,54 @@ import lsst.pipe.base.argumentParser as base_parser
 # Local non-exported definitions --
 #----------------------------------
 
-# Class which keeps a single override, each -c and -C option is converted into
-# instance of this class and are put in a single ordered collection so that
-# overrides can be applied later.
-_Override = collections.namedtuple("_Override", "type,value")
+# Class which determines an action that needs to be performed
+# when building pipeline, its attributes are:
+#   action: the name of the action, e.g. "new_task", "delete_task"
+#   label:  task label, can be None if action does not require label
+#   value:  argument value excluding task label.
+_PipelineAction = collections.namedtuple("_PipelineAction", "action,label,value")
+
+class _PipelineActionType(object):
+    """Class defining a callable type which converts strings into
+    _PipelineAction instances.
+
+    Parameters
+    ----------
+    action : str
+        Name of the action, will become `action` attribute of instance.
+    regex : str
+        Regular expression for argument value, it can define groups 'label'
+        and 'value' which will become corresponding attributes of a
+        returned instance.
+    """
+
+    def __init__(self, action, regex='.*'):
+        self.action = action
+        self.regex = re.compile(regex)
+
+    def __call__(self, value):
+        match = self.regex.match(value)
+        if not match:
+            raise TypeError("Unrecognized option syntax: " + value)
+        # get "label" group or use None as label
+        try:
+            label = match.group("label")
+        except IndexError:
+            label = None
+        # if "value" group is not defined use whole string
+        try:
+            value = match.group("value")
+        except IndexError:
+            pass
+        return _PipelineAction(self.action, label, value)
+
+
+_ACTION_ADD_TASK = _PipelineActionType("new_task", "(?P<value>[^:]+)(:(?P<label>.+))?")
+_ACTION_DELETE_TASK = _PipelineActionType("delete_task", "(?P<value>)(?P<label>.+)")
+_ACTION_MOVE_TASK = _PipelineActionType("move_task", "(?P<label>.+):(?P<value>-?\d+)")
+_ACTION_LABEL_TASK = _PipelineActionType("relabel", "(?P<label>.+):(?P<value>.+)")
+_ACTION_CONFIG = _PipelineActionType("config", "(?P<label>[^.]+)[.](?P<value>.+=.+)")
+_ACTION_CONFIG_FILE = _PipelineActionType("configfile", "(?P<label>.+):(?P<value>.+)")
 
 
 class _LogLevelAction(Action):
@@ -83,58 +128,6 @@ class _LogLevelAction(Action):
             parser.error("loglevel=%s not one of %s" % (levelStr, tuple(self.permittedLevels)))
         dest.append((component, logLevelUpr))
 
-
-class _AppendFlattenAction(Action):
-    """Action class which appends all items of multi-value option to the
-    same destination.
-
-    This is different from standard 'append' action which does not flatten
-    the option values.
-    """
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        """Re-implementation of the base class method.
-
-        See `argparse.Action` documentation for parameter description.
-        """
-        dest = getattr(namespace, self.dest)
-        if dest is None:
-            dest = []
-            setattr(namespace, self.dest, dest)
-        dest += values
-
-
-class _TaskConfigAction(Action):
-    """Action class which associates config overrides with tasks.
-
-    Adds overrides to a list which matches the size of the task list.
-    This class needs to know the name of the (attribute for) task list,
-    there is no easy way to pass it during construction, so for now
-    that name is hard-coded in taskListName attribute.
-    """
-    taskListName = "taskname"   # namespace attribute which holds task list
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        """Re-implementation of the base class method.
-
-        See `argparse.Action` documentation for parameter description.
-        """
-        # make sure that at least one task name already there
-        taskList = getattr(namespace, self.taskListName)
-        if not taskList:
-            parser.error("option %s must follow task name" % option_string)
-
-        # get or make config list
-        dest = getattr(namespace, self.dest)
-        if dest is None:
-            dest = []
-            setattr(namespace, self.dest, dest)
-
-        # extend config list to the same length as task list
-        dest.extend([None] * (len(taskList) - len(dest)))
-        if dest[-1] is None:
-            dest[-1] = []
-        dest[-1].append(values)
 
 # copied with small mods from pipe.base.argumentParser
 class _IdValueAction(Action):
@@ -224,8 +217,8 @@ def _config_file(value):
 
 _EPILOG = """\
 Notes:
-  * --task, --config, --configfile, --id, --loglevel and @file may appear
-    multiple times; all values are used, in order left to right
+  * many options can appear multiple times; all values are used, in order
+    left to right
   * @file reads command-line options from the specified file:
     * data may be distributed among multiple lines (e.g. one option per line)
     * data after # is treated as a comment and ignored
@@ -368,47 +361,85 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
     subparser.add_argument("--no-headers", dest="show_headers", action="store_false", default=True,
                            help="Do not display any headers on output")
 
-    for subcommand in ("show", "run"):
+    for subcommand in ("build", "qgraph", "run"):
         # show/run sub-commands, they are all identical except for the
         # command itself and description
 
-        if subcommand == "show":
+        if subcommand == "build":
             description = textwrap.dedent("""\
-                Display various information about given pipeline. By default all information is
-                displayed, use options to select only subset of the information.""")
+                Build and optionally save pipeline definition.
+                This does not require input data to be specified.""")
+        elif subcommand == "qgraph":
+            description = textwrap.dedent("""\
+                Build and optionally save pipeline and quantum graph.""")
         else:
             description = textwrap.dedent("""\
-                Execute specified pipeline.""")
+                Build and execute pipeline and quantum graph.""")
 
         subparser = subparsers.add_parser(subcommand,
-                                          usage="`%(prog)s -t taskname [options] [-t taskname ...]' or "
-                                          "`%(prog)s -p path [options]'",
                                           description=description,
                                           epilog=_EPILOG,
                                           formatter_class=RawDescriptionHelpFormatter)
-        subparser.set_defaults(subparser=subparser)
-        excl_group = subparser.add_mutually_exclusive_group(required=True)
-        excl_group.add_argument("-p", "--pipeline", dest="pipeline",
-                                help="Location of a serialized pipeline definition (pickle file)."
-                                " This option cannot be used together with task names.",
-                                metavar="PATH")
-        excl_group.add_argument("-t", "--task", dest="taskname", action='append',
-                                help="Names of the tasks to execute. It can be a simple name without dots "
-                                "which will be found in one of the modules located in the known "
-                                "packages or packages specified in --package option. If name contains dots "
-                                "it is assumed to be a fully qualified name of a class found in $PYTHONPATH "
-                                "or in one of the packages specified in --package option.")
-        subparser.add_argument("-c", "--config", dest="config_overrides",
-                               action=_TaskConfigAction, type=_config_override, metavar="NAME=VALUE",
-                               help="Configuration override(s), e.g. -c foo=newfoo -c bar.baz=3. "
-                               "This option applies to a preceding task.")
-        subparser.add_argument("-C", "--configfile", dest="config_overrides",
-                               action=_TaskConfigAction, type=_config_file, metavar="PATH",
-                               help="Configuration override file(s). "
-                               "This option applies to a preceding task.")
-        subparser.add_argument("--save-pipeline", dest="save_pipeline",
+        subparser.set_defaults(subparser=subparser,
+                               pipeline_actions=[])
+        if subcommand == "run":
+            subparser.add_argument("-g", "--qgraph", dest="qgraph",
+                                   help="Location for a serialized quantum graph definition "
+                                   "(pickle file). If this option is given then all input data "
+                                   "options and pipeline-building options cannot be used.",
+                                   metavar="PATH")
+        subparser.add_argument("-p", "--pipeline", dest="pipeline",
+                               help="Location of a serialized pipeline definition (pickle file).",
+                               metavar="PATH")
+        subparser.add_argument("--camera-overrides", dest="camera_overrides",
+                               default=False, action="store_true",
+                               help="Apply standard camera and package overrides "
+                               "to configuration of new tasks.")
+        subparser.add_argument("-t", "--task", metavar="TASK[:LABEL]",
+                               dest="pipeline_actions", action='append', type=_ACTION_ADD_TASK,
+                               help="Task name to add to pipeline, can be either full name "
+                               "with dots including package and module name, or a simple name "
+                               "to find the class in one of the modules in pre-defined packages "
+                               "(see --packages option). Task name can be followed by colon and "
+                               "label name, if label is not given than task base name (class name) "
+                               "is used as label.")
+        subparser.add_argument("-d", "--delete", metavar="LABEL",
+                               dest="pipeline_actions", action='append', type=_ACTION_DELETE_TASK,
+                               help="Delete task with given label from pipeline.")
+        subparser.add_argument("-m", "--move", metavar="LABEL:NUMBER",
+                               dest="pipeline_actions", action='append', type=_ACTION_MOVE_TASK,
+                               help="Move given task to a different position in a pipeline.")
+        subparser.add_argument("-l", "--label", metavar="LABEL:NEW_LABEL",
+                               dest="pipeline_actions", action='append', type=_ACTION_LABEL_TASK,
+                               help="Change label of a given task.")
+        subparser.add_argument("-c", "--config", metavar="LABEL.NAME=VALUE",
+                               dest="pipeline_actions", action='append', type=_ACTION_CONFIG,
+                               help="Configuration override(s) for a task with specified label, "
+                               "e.g. -c task.foo=newfoo -c task.bar.baz=3.")
+        subparser.add_argument("-C", "--configfile", metavar="LABEL:PATH",
+                               dest="pipeline_actions", action='append', type=_ACTION_CONFIG_FILE,
+                               help="Configuration override file(s), applies to a task with a given label.")
+        subparser.add_argument("-o", "--order-pipeline", dest="order_pipeline",
+                               default=False, action="store_true",
+                               help="Order tasks in pipeline based on their data dependencies, "
+                               "ordering is performed as last step before saving or executing "
+                               "pipeline.")
+        subparser.add_argument("-s", "--save-pipeline", dest="save_pipeline",
                                help="Location for storing a serialized pipeline definition (pickle file).",
                                metavar="PATH")
+        if subcommand in ("qgraph", "run"):
+            subparser.add_argument("-q", "--save-qgraph", dest="save_qgraph",
+                                   help="Location for storing a serialized quantum graph definition "
+                                   "(pickle file).",
+                                   metavar="PATH")
+        subparser.add_argument("--pipeline-dot", dest="pipeline_dot",
+                               help="Location for storing GraphViz DOT representation of a pipeline.",
+                               metavar="PATH")
+        if subcommand in ("qgraph", "run"):
+            subparser.add_argument("--qgraph-dot", dest="qgraph_dot",
+                                   help="Location for storing GraphViz DOT representation of a "
+                                   "quantum graph.",
+                                   metavar="PATH")
         subparser.add_argument("--show", metavar="ITEM|ITEM=VALUE", action="append", default=[],
                                help="Dump various info to standard output. Possible items are: "
                                "`config', `config=[Task/]<PATTERN>' or `config=[Task::]<PATTERN>:NOIGNORECASE' "

--- a/python/lsst/pipe/supertask/pipeTools.py
+++ b/python/lsst/pipe/supertask/pipeTools.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2018 LSST Corporation.
+# Copyright 2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/pipeTools.py
+++ b/python/lsst/pipe/supertask/pipeTools.py
@@ -41,7 +41,7 @@ from .pipeline import Pipeline
 #----------------------------------
 
 def _loadTaskClass(taskDef, taskFactory):
-    """Import task class it necessary.
+    """Import task class if necessary.
 
     Raises
     ------
@@ -163,7 +163,7 @@ def orderPipeline(pipeline, taskFactory=None):
     provided.
     """
 
-    # This is a modified version of Khan's algorithm that preserveds order
+    # This is a modified version of Kahn's algorithm that preserves order
 
     # build mapping of the tasks to their inputs and outputs
     inputs = {}   # maps task index to its input DatasetType names

--- a/python/lsst/pipe/supertask/pipeline.py
+++ b/python/lsst/pipe/supertask/pipeline.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017-2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/pipeline.py
+++ b/python/lsst/pipe/supertask/pipeline.py
@@ -108,6 +108,14 @@ class Pipeline(list):
     def __init__(self, iterable=None):
         list.__init__(self, iterable or [])
 
+    def labelIndex(self, label):
+        """Return task index given its label, returns -1 if label is not found
+        """
+        for idx, taskDef in enumerate(self):
+            if taskDef.label == label:
+                return idx
+        return -1
+
     def __str__(self):
         infos = [str(tdef) for tdef in self]
         return "Pipeline({})".format(", ".join(infos))

--- a/python/lsst/pipe/supertask/pipelineBuilder.py
+++ b/python/lsst/pipe/supertask/pipelineBuilder.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2018 LSST Corporation.
+# Copyright 2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/pipelineBuilder.py
+++ b/python/lsst/pipe/supertask/pipelineBuilder.py
@@ -1,0 +1,285 @@
+#
+# LSST Data Management System
+# Copyright 2018 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+"""
+Module defining PipelineBuilder class and related methods.
+"""
+
+from __future__ import print_function
+from builtins import object
+
+__all__ = ['PipelineBuilder']
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+import os
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+from .configOverrides import ConfigOverrides
+from .pipeline import Pipeline, TaskDef
+from . import pipeTools
+import lsst.daf.persistence as dafPersist
+import lsst.log as lsstLog
+import lsst.utils
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+
+class PipelineBuilder(object):
+    """
+    PipelineBuilder class is responsible for building task pipeline from
+    a set of command line arguments.
+
+    Parameters
+    ----------
+    taskFactory : `TaskFactory`
+        Factory object used to load/instantiate SuperTasks
+    """
+
+    def __init__(self, taskFactory):
+        self.taskFactory = taskFactory
+
+    def makePipeline(self, args):
+        """Build pipeline from command line arguments.
+
+        Parameters
+        ----------
+        args : `argparse.Namespace`
+            Parsed command line.
+
+        Returns
+        -------
+        `Pipeline` instance.
+
+        Raises
+        ------
+        Exceptions will be raised for any kind of error conditions.
+        """
+
+        # need camera/package name to find overrides
+        obsPkg = None
+        camera = None
+        if args.camera_overrides:
+            mapperClass = dafPersist.Butler.getMapperClass(args.input)
+            camera = mapperClass.getCameraName()
+            obsPkg = mapperClass.getPackageName()
+
+        if args.pipeline:
+
+            # load it from a pickle file, will raise on error
+            with open(args.pipeline) as pickleFile:
+                pipeline = pickle.load(pickleFile)
+
+            # check type
+            if not isinstance(pipeline, Pipeline):
+                raise TypeError("Pickle file `{}' contains something other than Pipeline".format(args.pipeline))
+
+        else:
+            # start with empty one
+            pipeline = Pipeline()
+
+        # loop over all pipeline actions and apply them in order
+        for action in args.pipeline_actions:
+
+            if action.action == "new_task":
+
+                self._newTask(pipeline, action.value, action.label, obsPkg, camera)
+
+            elif action.action == "delete_task":
+
+                self._dropTask(pipeline, action.label)
+
+            elif action.action == "move_task":
+
+                self._moveTask(pipeline, action.label, int(action.value))
+
+            elif action.action == "relabel":
+
+                self._labelTask(pipeline, action.label, action.value)
+
+            elif action.action == "config":
+
+                self._configOverride(pipeline, action.label, action.value)
+
+            elif action.action == "configfile":
+
+                self._configOverrideFile(pipeline, action.label, action.value)
+
+        # re-order pipeline if requested, this also checks for possible errors
+        if args.order_pipeline:
+            pipeline = pipeTools.orderPipeline(pipeline, self.taskFactory)
+
+        return pipeline
+
+    def _newTask(self, pipeline, taskName, label=None, obsPkg=None, camera=None):
+        """Append new task to a pipeline.
+
+        Parameters
+        ----------
+        pipeline : py:class:`Pipeline`
+            Pipeline instance.
+        taskName : `str`
+            Name of the new task, can be either full class name including
+            package and module, or just a class name to be searched in
+            known packages and modules.
+        label : `str`, optional
+            Label for new task, if `None` the n task class name is used as
+            label.
+        obsPkg : `str`, optional
+            Name of the package to look for task overrides, if None then
+            overrides are not used.
+        camera : `str`, optional
+            Camera name, used for camera-specific overrides an only if
+            `obsPkg` is not `None`.
+        """
+        # load task class, will throw on errors
+        taskClass, taskName = self.taskFactory.loadTaskClass(taskName)
+
+        # get label and check that it is unique
+        if not label:
+            label = taskName.rpartition('.')[2]
+        if pipeline.labelIndex(label) >= 0:
+            raise LookupError("Task label (or name) is not unique: " + label)
+
+        # make config instance with defaults
+        config = taskClass.ConfigClass()
+
+        # apply camera/package overrides
+        if obsPkg:
+            obsPkgDir = lsst.utils.getPackageDir(obsPkg)
+            configName = taskClass._DefaultName
+            fileName = configName + ".py"
+            overrides = ConfigOverrides()
+            for filePath in (
+                os.path.join(obsPkgDir, "config", fileName),
+                os.path.join(obsPkgDir, "config", camera, fileName),
+            ):
+                if os.path.exists(filePath):
+                    lsstLog.info("Loading config overrride file %r", filePath)
+                    overrides.addFileOverride(filePath)
+                else:
+                    lsstLog.debug("Config override file does not exist: %r", filePath)
+
+            overrides.applyTo(config)
+
+        pipeline.append(TaskDef(taskName=taskName, config=config,
+                                taskClass=taskClass, label=label))
+
+    def _dropTask(self, pipeline, label):
+        """Remove task from a pipeline.
+
+        Parameters
+        ----------
+        pipeline : py:class:`Pipeline`
+            Pipeline instance.
+        label : `str`
+            Label of the task to remove.
+        """
+        idx = pipeline.labelIndex(label)
+        if idx < 0:
+            raise LookupError("Task label is not found: " + label)
+        del pipeline[idx]
+
+    def _moveTask(self, pipeline, label, new_idx):
+        """Move task to a new position in a pipeline.
+
+        Parameters
+        ----------
+        pipeline : py:class:`Pipeline`
+            Pipeline instance.
+        label : `str`
+            Label of the task to move.
+        new_idx : `int`
+            New position.
+        """
+        idx = pipeline.labelIndex(label)
+        if idx < 0:
+            raise LookupError("Task label is not found: " + label)
+        pipeline.insert(new_idx, pipeline.pop(idx))
+
+    def _labelTask(self, pipeline, label, newLabel):
+        """Change task label.
+
+        Parameters
+        ----------
+        pipeline : py:class:`Pipeline`
+            Pipeline instance.
+        label : `str`
+            Existing label of the task.
+        newLabel : `str`
+            New label of the task.
+        """
+        idx = pipeline.labelIndex(label)
+        if idx < 0:
+            raise LookupError("Task label is not found: " + label)
+        # check that new one is unique
+        if newLabel != label and pipeline.labelIndex(newLabel) >= 0:
+            raise LookupError("New task label is not unique: " + label)
+        pipeline[idx].label = newLabel
+
+    def _configOverride(self, pipeline, label, value):
+        """Apply single config override.
+
+        Parameters
+        ----------
+        pipeline : py:class:`Pipeline`
+            Pipeline instance.
+        label : `str`
+            Label of the task.
+        value : `str`
+            String in the form "param = value".
+        """
+        idx = pipeline.labelIndex(label)
+        if idx < 0:
+            raise LookupError("Task label is not found: " + label)
+        key, sep, val = value.partition('=')
+        overrides = ConfigOverrides()
+        overrides.addValueOverride(key, val)
+        overrides.applyTo(pipeline[idx].config)
+
+    def _configOverrideFile(self, pipeline, label, value):
+        """Apply overrides from file.
+
+        Parameters
+        ----------
+        pipeline : py:class:`Pipeline`
+            Pipeline instance.
+        label : `str`
+            Label of the task.
+        value : `str`
+            Path to file with overrides.
+        """
+        idx = pipeline.labelIndex(label)
+        if idx < 0:
+            raise LookupError("Task label is not found: " + label)
+        key, sep, val = value.partition('=')
+        overrides = ConfigOverrides()
+        overrides.addFileOverride(value)
+        overrides.applyTo(pipeline[idx].config)

--- a/python/lsst/pipe/supertask/pipelineTools.py
+++ b/python/lsst/pipe/supertask/pipelineTools.py
@@ -1,0 +1,107 @@
+#
+# LSST Data Management System
+# Copyright 2018 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+"""
+Module defining few methods to manipulate or query pipelines.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__all__ = ["isPipelineOrdered"]
+
+#--------------------------------
+#  Imports of standard modules --
+#--------------------------------
+import sys
+
+#-----------------------------
+# Imports for other modules --
+#-----------------------------
+from .config import InputDatasetConfig, OutputDatasetConfig
+
+#----------------------------------
+# Local non-exported definitions --
+#----------------------------------
+
+#------------------------
+# Exported definitions --
+#------------------------
+
+
+def isPipelineOrdered(pipeline, taskFactory=None):
+    """Checks whether tasks in pipeline are correctly ordered.
+
+    Pipeline is correctly ordered if for any DatasetType produced by a task
+    in a pipeline all its consumer tasks are located after producer.
+
+    Parameters
+    ----------
+    pipeline : `pipe.supertask.Pipeline`
+        Pipeline description.
+    taskFactory: `pipe.supertask.TaskFactory`, optional
+        Instance of an object which knows how to import task classes. It is only
+        used if pipeline task definitions do not define task classes.
+
+    Returns
+    -------
+    True for correctly ordered pipeline, False otherwise.
+
+    Raises
+    ------
+    `ImportError` is raised when task class cannot be imported.
+    `ValueError` is raised when there is more than one producer for a dataset
+    type.
+    `ValueError` is also raised when TaskFactory is needed but not provided.
+    """
+    # Build a map of DatasetType name to producer's index in a pipeline
+    producerIndex = {}
+    for idx, taskDef in enumerate(pipeline):
+
+        # we will need task class for next operations, make sure it is loaded
+        if not taskDef.taskClass:
+            if not taskFactory:
+                raise ValueError("Task class is not defined but task factory "
+                                 "instance is not provided")
+            taskDef.taskClass = taskFactory.loadTaskClass(taskDef.taskName)
+
+        # get task output DatasetTypes, this can only be done via class method
+        outputs = taskDef.taskClass.getOutputDatasetTypes(taskDef.config)
+        for dsType in outputs.values():
+            if dsType.name in producerIndex:
+                raise ValueError("DatasetType `{}' appears more than once as"
+                                 " output".format(dsType.name))
+            producerIndex[dsType.name] = idx
+
+    print(producerIndex)
+
+    # check all inputs that are also someone's outputs
+    for idx, taskDef in enumerate(pipeline):
+
+        # get task input DatasetTypes, this can only be done via class method
+        inputs = taskDef.taskClass.getInputDatasetTypes(taskDef.config)
+        for dsType in inputs.values():
+            # all pre-existing datasets have effective index -1
+            prodIdx = producerIndex.get(dsType.name, -1)
+            if prodIdx >= idx:
+                # not good, producer is downstream
+                return False
+
+    return True

--- a/python/lsst/pipe/supertask/superTask.py
+++ b/python/lsst/pipe/supertask/superTask.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2008, 2009, 2010, 2011 LSST Corporation.
+# Copyright 2016-2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/taskLoader.py
+++ b/python/lsst/pipe/supertask/taskLoader.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/python/lsst/pipe/supertask/util.py
+++ b/python/lsst/pipe/supertask/util.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -2,7 +2,7 @@
 """
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017-2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -120,9 +120,9 @@ class TaskTwo(OneToOneTask):
 class TaskFactoryMock(object):
     def loadTaskClass(self, taskName):
         if taskName == "TaskOne":
-            return TaskOne
+            return TaskOne, "TaskOne"
         elif taskName == "TaskTwo":
-            return TaskTwo
+            return TaskTwo, "TaskTwo"
 
     def makeTask(self, taskClass, config, overrides, butler):
         if config is None:

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2016-2017 LSST Corporation.
+# Copyright 2016-2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_pipeTools.py
+++ b/tests/test_pipeTools.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_pipeTools.py
+++ b/tests/test_pipeTools.py
@@ -29,7 +29,7 @@ from collections import namedtuple
 
 import lsst.pex.config as pexConfig
 from lsst.pipe import supertask
-import lsst.pipe.supertask.pipelineTools as pipeTools
+from lsst.pipe.supertask import pipeTools
 import lsst.utils.tests
 
 # mock for actual dataset type

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2017 LSST Corporation.
+# Copyright 2017 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_pipelineBuilder.py
+++ b/tests/test_pipelineBuilder.py
@@ -1,0 +1,337 @@
+#
+# LSST Data Management System
+# Copyright 2018 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Simple unit test for PipelineBuilder.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from argparse import Namespace
+from tempfile import NamedTemporaryFile
+import os
+import unittest
+from builtins import object
+
+import lsst.utils.tests
+from lsst.log import Log
+import lsst.pex.config as pexConfig
+from lsst.pipe.supertask import PipelineBuilder, SuperTask, SuperTaskConfig, parser
+
+
+class SimpleConfig(SuperTaskConfig):
+    field = pexConfig.Field(dtype=str, doc="arbitrary string")
+
+
+class TaskOne(SuperTask):
+    ConfigClass = SimpleConfig
+    _DefaultName = "taskOne"
+    def __init__(self, **kwargs):
+        OneToOneTask.__init__(self, Dataset1, Dataset2, **kwargs)
+
+
+class TaskTwo(SuperTask):
+    ConfigClass = SimpleConfig
+    _DefaultName = "taskTwo"
+    def __init__(self, **kwargs):
+        OneToOneTask.__init__(self, Dataset2, Dataset3, **kwargs)
+
+
+class TaskFactoryMock(object):
+    def loadTaskClass(self, taskName):
+        if taskName == "TaskOne":
+            return TaskOne, "TaskOne"
+        elif taskName == "TaskTwo":
+            return TaskTwo, "TaskTwo"
+
+    def makeTask(self, taskClass, config, overrides, butler):
+        if config is None:
+            config = taskClass.ConfigClass()
+            if overrides:
+                overrides.applyTo(config)
+        return taskClass(config=config, butler=butler)
+
+
+class PipelineBuilderTestCase(unittest.TestCase):
+    """A test case for PipelineBuilder class
+    """
+
+    def setUp(self):
+        self.builder = PipelineBuilder(TaskFactoryMock())
+
+    def tearDown(self):
+        del self.builder
+
+    def test_AddTasks(self):
+        """Simple test case adding tasks to a pipeline
+        """
+        # create a task with default label
+        actions = [parser._ACTION_ADD_TASK("TaskOne")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 1)
+        self.assertEqual(pipeline[0].taskName, "TaskOne")
+        self.assertEqual(pipeline[0].label, "TaskOne")
+        self.assertIs(pipeline[0].taskClass, TaskOne)
+
+        # create a task, give it a label
+        actions = [parser._ACTION_ADD_TASK("TaskOne:label")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 1)
+        self.assertEqual(pipeline[0].taskName, "TaskOne")
+        self.assertEqual(pipeline[0].label, "label")
+        self.assertIs(pipeline[0].taskClass, TaskOne)
+
+        # two different tasks
+        actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                   parser._ACTION_ADD_TASK("TaskTwo")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 2)
+        self.assertEqual(pipeline[0].taskName, "TaskOne")
+        self.assertEqual(pipeline[0].label, "TaskOne")
+        self.assertIs(pipeline[0].taskClass, TaskOne)
+        self.assertEqual(pipeline[1].taskName, "TaskTwo")
+        self.assertEqual(pipeline[1].label, "TaskTwo")
+        self.assertIs(pipeline[1].taskClass, TaskTwo)
+
+        # more than one instance of each class
+        actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                   parser._ACTION_ADD_TASK("TaskTwo"),
+                   parser._ACTION_ADD_TASK("TaskOne:label"),
+                   parser._ACTION_ADD_TASK("TaskTwo:label2")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 4)
+        self.assertEqual(pipeline[0].taskName, "TaskOne")
+        self.assertEqual(pipeline[0].label, "TaskOne")
+        self.assertEqual(pipeline[1].taskName, "TaskTwo")
+        self.assertEqual(pipeline[1].label, "TaskTwo")
+        self.assertEqual(pipeline[2].taskName, "TaskOne")
+        self.assertEqual(pipeline[2].label, "label")
+        self.assertEqual(pipeline[3].taskName, "TaskTwo")
+        self.assertEqual(pipeline[3].label, "label2")
+
+    def test_LabelExceptions(self):
+        """Simple test case adding tasks with identical labels
+        """
+        actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                   parser._ACTION_ADD_TASK("TaskOne")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+        args.pipeline_actions = [parser._ACTION_ADD_TASK("TaskOne:label"),
+                                 parser._ACTION_ADD_TASK("TaskTwo:label")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+    def test_DeleteTask(self):
+        """Simple test case removing tasks
+        """
+        # make short pipeline
+        actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                   parser._ACTION_ADD_TASK("TaskTwo"),
+                   parser._ACTION_ADD_TASK("TaskOne:label"),
+                   parser._ACTION_ADD_TASK("TaskTwo:label2")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 4)
+
+        args.pipeline_actions += [parser._ACTION_DELETE_TASK("label")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 3)
+
+        args.pipeline_actions += [parser._ACTION_DELETE_TASK("TaskTwo")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 2)
+
+        args.pipeline_actions += [parser._ACTION_DELETE_TASK("TaskOne"),
+                                  parser._ACTION_DELETE_TASK("label2")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(len(pipeline), 0)
+
+        # unknown label should raise LookupError
+        args.pipeline_actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                                 parser._ACTION_ADD_TASK("TaskTwo"),
+                                 parser._ACTION_DELETE_TASK("label2")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+    def test_MoveTask(self):
+        """Simple test case moving tasks
+        """
+        # make short pipeline
+        actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                   parser._ACTION_ADD_TASK("TaskTwo"),
+                   parser._ACTION_ADD_TASK("TaskOne:label"),
+                   parser._ACTION_ADD_TASK("TaskTwo:label2")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["TaskOne", "TaskTwo", "label", "label2"])
+
+        args.pipeline_actions += [parser._ACTION_MOVE_TASK("label:1")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["TaskOne", "label", "TaskTwo", "label2"])
+
+        # negatives are accepted but may be non-intuitive
+        args.pipeline_actions += [parser._ACTION_MOVE_TASK("TaskOne:-1")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["label", "TaskTwo", "TaskOne", "label2"])
+
+        # position larger than list size moves to end
+        args.pipeline_actions += [parser._ACTION_MOVE_TASK("label:100")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["TaskTwo", "TaskOne", "label2", "label"])
+
+        args.pipeline_actions += [parser._ACTION_MOVE_TASK("label:0")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["label", "TaskTwo", "TaskOne", "label2"])
+
+        # unknown label should raise LookupError
+        args.pipeline_actions += [parser._ACTION_MOVE_TASK("unlabel:0")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+    def test_LabelTask(self):
+        """Simple test case re-labeling tasks
+        """
+        # make short pipeline
+        actions = [parser._ACTION_ADD_TASK("TaskOne"),
+                   parser._ACTION_ADD_TASK("TaskTwo"),
+                   parser._ACTION_ADD_TASK("TaskOne:label"),
+                   parser._ACTION_ADD_TASK("TaskTwo:label2")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["TaskOne", "TaskTwo", "label", "label2"])
+
+        args.pipeline_actions += [parser._ACTION_LABEL_TASK("TaskOne:label0")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual([t.label for t in pipeline],
+                         ["label0", "TaskTwo", "label", "label2"])
+
+        # unknown label should raise LookupError
+        args.pipeline_actions += [parser._ACTION_LABEL_TASK("unlabel:label3")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+        # duplicate label should raise LookupError
+        args.pipeline_actions += [parser._ACTION_LABEL_TASK("label2:label0")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+    def test_ConfigTask(self):
+        """Simple test case for config overrides
+        """
+        # make simple pipeline
+        actions = [parser._ACTION_ADD_TASK("TaskOne:task")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertIsInstance(pipeline[0].config, SimpleConfig)
+        self.assertIsNone(pipeline[0].config.field)
+
+        args.pipeline_actions += [parser._ACTION_CONFIG("task.field=value")]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(pipeline[0].config.field, "value")
+
+        # unknown label should raise LookupError
+        args.pipeline_actions += [parser._ACTION_CONFIG("label.field=value")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+    def test_ConfigFileTask(self):
+        """Simple test case for config overrides in file
+        """
+        # make simple pipeline
+        actions = [parser._ACTION_ADD_TASK("TaskOne:task"),
+                   parser._ACTION_CONFIG("task.field=value")]
+        args = Namespace(camera_overrides=False,
+                         pipeline=None,
+                         pipeline_actions=actions,
+                         order_pipeline=False)
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(pipeline[0].config.field, "value")
+
+        # save config to file for next test
+        overrides = NamedTemporaryFile(mode="wt", delete=False)
+        pipeline[0].config.saveToStream(overrides)
+        fname = overrides.name
+        del overrides
+
+        args.pipeline_actions = [parser._ACTION_ADD_TASK("TaskOne:task"),
+                                 parser._ACTION_CONFIG_FILE("task:" + fname)]
+        pipeline = self.builder.makePipeline(args)
+        self.assertEqual(pipeline[0].config.field, "value")
+
+        os.unlink(fname)
+
+        # unknown label should raise LookupError
+        args.pipeline_actions = [parser._ACTION_ADD_TASK("TaskOne:task"),
+                                 parser._ACTION_CONFIG_FILE("label:/dev/null")]
+        with self.assertRaises(LookupError):
+            self.builder.makePipeline(args)
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    actions = []
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_pipelineBuilder.py
+++ b/tests/test_pipelineBuilder.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2018 LSST Corporation.
+# Copyright 2018 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_pipelineTools.py
+++ b/tests/test_pipelineTools.py
@@ -1,0 +1,141 @@
+#
+# LSST Data Management System
+# Copyright 2017 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Simple unit test for Pipeline.
+"""
+
+import unittest
+import pickle
+from collections import namedtuple
+
+import lsst.pex.config as pexConfig
+from lsst.pipe.supertask import (Pipeline, SuperTask, TaskDef,
+                                 isPipelineOrdered,
+                                 SuperTaskConfig, InputDatasetConfig,
+                                 OutputDatasetConfig)
+import lsst.utils.tests
+
+# mock for actual dataset type
+DS = namedtuple("DS", "name units")
+def makeDatasetType(dsConfig):
+    return DS(name=dsConfig.name, units=dsConfig.units)
+
+
+class AddConfig(SuperTaskConfig):
+    input = pexConfig.ConfigField(dtype=InputDatasetConfig,
+                                  doc="Input for this task")
+    output = pexConfig.ConfigField(dtype=OutputDatasetConfig,
+                                   doc="Output for this task")
+
+    def setDefaults(self):
+        self.input.name = "raw"
+        self.input.units = ["Visit", "Sensor"]
+        self.output.name = "addraw"
+        self.output.units = ["Visit", "Sensor"]
+
+
+class AddTask(SuperTask):
+    ConfigClass = AddConfig
+
+    @classmethod
+    def getInputDatasetTypes(cls, config):
+        return {"input": makeDatasetType(config.input)}
+
+    @classmethod
+    def getOutputDatasetTypes(cls, config):
+        return {"output": makeDatasetType(config.output)}
+
+
+class MultConfig(SuperTaskConfig):
+    input = pexConfig.ConfigField(dtype=InputDatasetConfig,
+                                  doc="Input for this task")
+    output = pexConfig.ConfigField(dtype=OutputDatasetConfig,
+                                   doc="Output for this task")
+
+    def setDefaults(self):
+        self.input.name = "addraw"
+        self.input.units = ["Visit", "Sensor"]
+        self.output.name = "mulraw"
+        self.output.units = ["Visit", "Sensor"]
+
+
+class MultTask(SuperTask):
+    ConfigClass = MultConfig
+
+    @classmethod
+    def getInputDatasetTypes(cls, config):
+        return {"input": makeDatasetType(config.input)}
+
+    @classmethod
+    def getOutputDatasetTypes(cls, config):
+        return {"output": makeDatasetType(config.output)}
+
+
+class PipelineToolsTestCase(unittest.TestCase):
+    """A test case for pipelineTools
+    """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testIsOrdered(self):
+        """Tests for isPipelineOrdered method
+        """
+        pipeline = Pipeline([TaskDef("lsst.pipe.supertask.tests.AddTask", AddConfig(), AddTask),
+                             TaskDef("lsst.pipe.supertask.tests.MultTask", MultConfig(), MultTask)])
+        self.assertTrue(isPipelineOrdered(pipeline))
+
+        pipeline = Pipeline([TaskDef("lsst.pipe.supertask.tests.MultTask", MultConfig(), MultTask),
+                             TaskDef("lsst.pipe.supertask.tests.AddTask", AddConfig(), AddTask)])
+        self.assertFalse(isPipelineOrdered(pipeline))
+
+    def testIsOrderedExceptions(self):
+        """Tests for isPipelineOrdered method exceptions
+        """
+
+        # two producers should throw ValueError
+        pipeline = Pipeline([TaskDef("lsst.pipe.supertask.tests.AddTask", AddConfig(), AddTask),
+                             TaskDef("lsst.pipe.supertask.tests.AddTask", AddConfig(), AddTask),
+                             TaskDef("lsst.pipe.supertask.tests.MultTask", MultConfig(), MultTask)])
+        with self.assertRaises(ValueError):
+            isPipelineOrdered(pipeline)
+
+        # missing factory should throw ValueError
+        pipeline = Pipeline([TaskDef("lsst.pipe.supertask.tests.AddTask", AddConfig()),
+                             TaskDef("lsst.pipe.supertask.tests.MultTask", MultConfig())])
+        with self.assertRaises(ValueError):
+            isPipelineOrdered(pipeline)
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_resourceConfig.py
+++ b/tests/test_resourceConfig.py
@@ -2,7 +2,7 @@
 """
 #
 # LSST Data Management System
-# Copyright 2016 LSST Corporation.
+# Copyright 2016 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).

--- a/tests/test_superTask.py
+++ b/tests/test_superTask.py
@@ -1,6 +1,6 @@
 #
 # LSST Data Management System
-# Copyright 2016-2017 LSST Corporation.
+# Copyright 2016-2017 AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).


### PR DESCRIPTION
- Adds  pipeTool module with methods to order and verify pipelines.
- parser module is updated with a bunch of options for pipeline construction
- there are also few new quantum graph related options, not used yet
- Pipeline construction code is moved into pipelineBuilder module.
- pipeline-related code is more or less complete, the rest is still WIP, needs a lot more work to integrate with new registry