### PR TITLE
DM-15214: QuantumGraph option to filter existing output Datasets

### DIFF
--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -42,7 +42,7 @@ import sys
 #  Imports for other modules --
 # -----------------------------
 from lsst.base import disableImplicitThreading
-from lsst.daf.butler import (Butler, PreFlightCollectionsDef)
+from lsst.daf.butler import Butler, DatasetOriginInfoDef
 import lsst.log as lsstLog
 import lsst.pex.config as pexConfig
 from .graphBuilder import GraphBuilder
@@ -188,10 +188,10 @@ class CmdLineFwk(object):
             # use one from Butler (has to be configured in butler config)
             if not defaultInputs:
                 defaultInputs = [butler.collection]
-            coll = PreFlightCollectionsDef(defaultInputs=defaultInputs,
-                                           defaultOutput=defaultOutputs,
-                                           inputOverrides=inputs,
-                                           outputOverrides=outputs)
+            coll = DatasetOriginInfoDef(defaultInputs=defaultInputs,
+                                        defaultOutput=defaultOutputs,
+                                        inputOverrides=inputs,
+                                        outputOverrides=outputs)
 
             # make execution plan (a.k.a. DAG) for pipeline
             graphBuilder = GraphBuilder(self.taskFactory, butler.registry, args.skip_existing)

--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -32,6 +32,7 @@ __all__ = ['CmdLineFwk']
 #  Imports of standard modules --
 # -------------------------------
 import fnmatch
+import logging
 import multiprocessing
 import pickle
 import re
@@ -224,6 +225,11 @@ class CmdLineFwk(object):
             if level is not None:
                 logger = lsstLog.Log.getLogger(component or "")
                 logger.setLevel(level)
+
+        # Forward all Python logging to lsst.log
+        lgr = logging.getLogger()
+        lgr.setLevel(logging.DEBUG)
+        lgr.addHandler(lsstLog.LogHandler())
 
     def doList(self, show, show_headers):
         """Implementation of the "list" command.

--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -164,21 +164,21 @@ class CmdLineFwk(object):
             # stop here
             return 0
 
-        # make butler instance
-        butler = Butler(config=args.butler_config, collection=args.input,
-                        run=args.output)
-        registry = butler.registry
-        collection = butler.collection
-
         if args.qgraph:
             with open(args.qgraph, 'rb') as pickleFile:
                 qgraph = pickle.load(pickleFile)
             # TODO: pipeline is ignored in this case, make sure that user
             # does not specify any pipeline-related options
         else:
+            # Make butler instance. From this Butler we only need Registry
+            # instance. Input/output collections are handled by pre-flight
+            # and we don't want to be constrained here by Butler's restrictions
+            # on collection names.
+            butler = Butler(config=args.butler_config, collection=args.input)
+
             # make execution plan (a.k.a. DAG) for pipeline
-            graphBuilder = GraphBuilder(self.taskFactory, registry)
-            qgraph = graphBuilder.makeGraph(pipeline, collection, args.data_query)
+            graphBuilder = GraphBuilder(self.taskFactory, butler.registry)
+            qgraph = graphBuilder.makeGraph(pipeline, [args.input], args.output, args.data_query)
 
         if args.save_qgraph:
             with open(args.save_qgraph, "wb") as pickleFile:
@@ -188,7 +188,7 @@ class CmdLineFwk(object):
             graph2dot(qgraph, args.qgraph_dot)
 
         # optionally dump some info
-        self.showInfo(args.show, butler, pipeline, registry, qgraph)
+        self.showInfo(args.show, pipeline, qgraph)
 
         if args.subcommand == "qgraph":
             # stop here
@@ -196,6 +196,11 @@ class CmdLineFwk(object):
 
         # execute
         if args.subcommand == "run":
+
+            # make butler instance
+            butler = Butler(config=args.butler_config, collection=args.input,
+                            run=args.output)
+
             return self.runPipeline(qgraph, butler, args)
 
     @staticmethod
@@ -378,19 +383,15 @@ class CmdLineFwk(object):
         for key, obj in initOutputs.items():
             butler.put(obj, initOutputDatasetTypes[key], {})
 
-    def showInfo(self, showOpts, butler, pipeline, registry, graph):
+    def showInfo(self, showOpts, pipeline, graph):
         """Display useful info about pipeline and environment.
 
         Parameters
         ----------
         showOpts : `list` of `str`
             Defines what to show
-        butler : `Butler`
-            Data butler instance
         pipeline : `Pipeline`
             Pipeline definition
-        registry : `Registry`
-            Registry instance
         graph : `QuantumGraph`
             Execution graph.
         """

--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -194,7 +194,7 @@ class CmdLineFwk(object):
                                            outputOverrides=outputs)
 
             # make execution plan (a.k.a. DAG) for pipeline
-            graphBuilder = GraphBuilder(self.taskFactory, butler.registry)
+            graphBuilder = GraphBuilder(self.taskFactory, butler.registry, args.skip_existing)
             qgraph = graphBuilder.makeGraph(pipeline, coll, args.data_query)
 
         if args.save_qgraph:

--- a/python/lsst/pipe/supertask/cmdLineParser.py
+++ b/python/lsst/pipe/supertask/cmdLineParser.py
@@ -388,6 +388,11 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
                                help="Order tasks in pipeline based on their data dependencies, "
                                "ordering is performed as last step before saving or executing "
                                "pipeline.")
+        if subcommand in ("qgraph", "run"):
+            subparser.add_argument("--skip-existing", dest="skip_existing",
+                                   default=False, action="store_true",
+                                   help="If all Quantum outputs already exist in output collection "
+                                   "then Qauntum will be excluded from QuantumGraph.")
         subparser.add_argument("-s", "--save-pipeline", dest="save_pipeline",
                                help="Location for storing a serialized pipeline definition (pickle file).",
                                metavar="PATH")

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -140,17 +140,15 @@ class GraphBuilder(object):
             taskDef.taskName = tName
         return taskDef
 
-    def makeGraph(self, pipeline, inputCollections, outputCollection, userQuery):
+    def makeGraph(self, pipeline, collections, userQuery):
         """Create execution graph for a pipeline.
 
         Parameters
         ----------
         pipeline : :py:class:`Pipeline`
             Pipeline definition, task names/classes and their configs.
-        inputCollections : `list` of `str`
-            Input collection names.
-        outputCollection : `str`
-            Output collection name.
+        collections : `PreFlightCollections`
+            Object which provides names of the input/output collections.
         userQuery : `str`
             String which defunes user-defined selection for registry, should be
             empty or `None` if there is no restrictions on data selection.
@@ -184,7 +182,7 @@ class GraphBuilder(object):
 
         # make a graph
         return self._makeGraph(taskDatasets, inputs, outputs,
-                               inputCollections, outputCollection, userQuery)
+                               collections, userQuery)
 
     def _makeFullIODatasetTypes(self, taskDatasets):
         """Returns full set of input and output dataset types for all tasks.
@@ -221,7 +219,7 @@ class GraphBuilder(object):
         outputs = set(allDatasetTypes[name] for name in outputs)
         return (inputs, outputs)
 
-    def _makeGraph(self, taskDatasets, inputs, outputs, inputCollections, outputCollection, userQuery):
+    def _makeGraph(self, taskDatasets, inputs, outputs, collections, userQuery):
         """Make QuantumGraph instance.
 
         Parameters
@@ -232,10 +230,8 @@ class GraphBuilder(object):
             Datasets which should already exist in input repository
         outputs : `set` of `DatasetType`
             Datasets which will be created by tasks
-        inputCollections : `list` of `str`
-            Input collection names.
-        outputCollection : `str`
-            Output collection name.
+        collections : `PreFlightCollections`
+            Object which provides names of the input/output collections.
         userQuery : `str`
             String which defunes user-defined selection for registry, should be
             empty or `None` if there is no restrictions on data selection.
@@ -246,7 +242,7 @@ class GraphBuilder(object):
         """
         parsedQuery = self._parseUserQuery(userQuery or "")
         expr = None if parsedQuery is None else str(parsedQuery)
-        rows = self.registry.selectDataUnits(inputCollections, outputCollection, expr, inputs, outputs)
+        rows = self.registry.selectDataUnits(collections, expr, inputs, outputs)
 
         # store result locally for multi-pass algorithm below
         # TODO: change it to single pass

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -140,15 +140,17 @@ class GraphBuilder(object):
             taskDef.taskName = tName
         return taskDef
 
-    def makeGraph(self, pipeline, collection, userQuery):
+    def makeGraph(self, pipeline, inputCollections, outputCollection, userQuery):
         """Create execution graph for a pipeline.
 
         Parameters
         ----------
         pipeline : :py:class:`Pipeline`
             Pipeline definition, task names/classes and their configs.
-        collection : `str`
-            Input collection name.
+        inputCollections : `list` of `str`
+            Input collection names.
+        outputCollection : `str`
+            Output collection name.
         userQuery : `str`
             String which defunes user-defined selection for registry, should be
             empty or `None` if there is no restrictions on data selection.
@@ -181,7 +183,8 @@ class GraphBuilder(object):
         inputs, outputs = self._makeFullIODatasetTypes(taskDatasets)
 
         # make a graph
-        return self._makeGraph(taskDatasets, inputs, outputs, collection, userQuery)
+        return self._makeGraph(taskDatasets, inputs, outputs,
+                               inputCollections, outputCollection, userQuery)
 
     def _makeFullIODatasetTypes(self, taskDatasets):
         """Returns full set of input and output dataset types for all tasks.
@@ -218,7 +221,7 @@ class GraphBuilder(object):
         outputs = set(allDatasetTypes[name] for name in outputs)
         return (inputs, outputs)
 
-    def _makeGraph(self, taskDatasets, inputs, outputs, collection, userQuery):
+    def _makeGraph(self, taskDatasets, inputs, outputs, inputCollections, outputCollection, userQuery):
         """Make QuantumGraph instance.
 
         Parameters
@@ -229,8 +232,10 @@ class GraphBuilder(object):
             Datasets which should already exist in input repository
         outputs : `set` of `DatasetType`
             Datasets which will be created by tasks
-        collection : `str`
-            Input collection name.
+        inputCollections : `list` of `str`
+            Input collection names.
+        outputCollection : `str`
+            Output collection name.
         userQuery : `str`
             String which defunes user-defined selection for registry, should be
             empty or `None` if there is no restrictions on data selection.
@@ -241,7 +246,7 @@ class GraphBuilder(object):
         """
         parsedQuery = self._parseUserQuery(userQuery or "")
         expr = None if parsedQuery is None else str(parsedQuery)
-        rows = self.registry.selectDataUnits([collection], expr, inputs, outputs)
+        rows = self.registry.selectDataUnits(inputCollections, outputCollection, expr, inputs, outputs)
 
         # store result locally for multi-pass algorithm below
         # TODO: change it to single pass

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -152,14 +152,14 @@ class GraphBuilder(object):
             taskDef.taskName = tName
         return taskDef
 
-    def makeGraph(self, pipeline, collections, userQuery):
+    def makeGraph(self, pipeline, originInfo, userQuery):
         """Create execution graph for a pipeline.
 
         Parameters
         ----------
         pipeline : :py:class:`Pipeline`
             Pipeline definition, task names/classes and their configs.
-        collections : `PreFlightCollections`
+        originInfo : `DatasetOriginInfo`
             Object which provides names of the input/output collections.
         userQuery : `str`
             String which defunes user-defined selection for registry, should be
@@ -196,7 +196,7 @@ class GraphBuilder(object):
 
         # make a graph
         return self._makeGraph(taskDatasets, inputs, outputs,
-                               collections, userQuery)
+                               originInfo, userQuery)
 
     def _makeFullIODatasetTypes(self, taskDatasets):
         """Returns full set of input and output dataset types for all tasks.
@@ -233,7 +233,7 @@ class GraphBuilder(object):
         outputs = set(allDatasetTypes[name] for name in outputs)
         return (inputs, outputs)
 
-    def _makeGraph(self, taskDatasets, inputs, outputs, collections, userQuery):
+    def _makeGraph(self, taskDatasets, inputs, outputs, originInfo, userQuery):
         """Make QuantumGraph instance.
 
         Parameters
@@ -244,7 +244,7 @@ class GraphBuilder(object):
             Datasets which should already exist in input repository
         outputs : `set` of `DatasetType`
             Datasets which will be created by tasks
-        collections : `PreFlightCollections`
+        originInfo : `DatasetOriginInfo`
             Object which provides names of the input/output collections.
         userQuery : `str`
             String which defunes user-defined selection for registry, should be
@@ -256,7 +256,7 @@ class GraphBuilder(object):
         """
         parsedQuery = self._parseUserQuery(userQuery or "")
         expr = None if parsedQuery is None else str(parsedQuery)
-        rows = self.registry.selectDataUnits(collections, expr, inputs, outputs)
+        rows = self.registry.selectDataUnits(originInfo, expr, inputs, outputs)
 
         # store result locally for multi-pass algorithm below
         # TODO: change it to single pass

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -179,7 +179,8 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         qgraph_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                           'order_pipeline', 'save_pipeline', 'pipeline_dot',
-                          'qgraph_dot', 'qgraph', 'save_qgraph', 'camera_overrides']
+                          'qgraph_dot', 'qgraph', 'save_qgraph', 'camera_overrides',
+                          'skip_existing']
         self.assertEqual(set(vars(args).keys()), set(global_options + qgraph_options))
         self.assertEqual(args.subcommand, 'qgraph')
 
@@ -189,7 +190,8 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         run_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                        'order_pipeline', 'save_pipeline', 'pipeline_dot',
-                       'qgraph_dot', 'qgraph', 'save_qgraph', 'camera_overrides']
+                       'qgraph_dot', 'qgraph', 'save_qgraph', 'camera_overrides',
+                       'skip_existing']
         self.assertEqual(set(vars(args).keys()), set(global_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -29,6 +29,7 @@ import unittest
 
 import lsst.utils.tests
 from lsst.daf.butler import (Registry, RegistryConfig, SchemaConfig,
+                             PreFlightCollectionsDef,
                              StorageClass, StorageClassFactory)
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
@@ -172,7 +173,8 @@ class GraphBuilderTestCase(unittest.TestCase):
         pipeline = self._makePipeline()
         collection = ""
         userQuery = None
-        graph = gbuilder.makeGraph(pipeline, [collection], collection, userQuery)
+        coll = PreFlightCollectionsDef([collection], collection)
+        graph = gbuilder.makeGraph(pipeline, coll, userQuery)
 
         self.assertEqual(len(graph), 2)
         taskDef = graph[0].taskDef
@@ -205,7 +207,8 @@ class GraphBuilderTestCase(unittest.TestCase):
         pipeline = self._makePipeline()
         collection = ""
         userQuery = "1 = 1"
-        graph = gbuilder.makeGraph(pipeline, [collection], collection, userQuery)
+        coll = PreFlightCollectionsDef([collection], collection)
+        graph = gbuilder.makeGraph(pipeline, coll, userQuery)
 
         self.assertEqual(len(graph), 2)
         taskDef = graph[0].taskDef

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -172,7 +172,7 @@ class GraphBuilderTestCase(unittest.TestCase):
         pipeline = self._makePipeline()
         collection = ""
         userQuery = None
-        graph = gbuilder.makeGraph(pipeline, collection, userQuery)
+        graph = gbuilder.makeGraph(pipeline, [collection], collection, userQuery)
 
         self.assertEqual(len(graph), 2)
         taskDef = graph[0].taskDef
@@ -205,7 +205,7 @@ class GraphBuilderTestCase(unittest.TestCase):
         pipeline = self._makePipeline()
         collection = ""
         userQuery = "1 = 1"
-        graph = gbuilder.makeGraph(pipeline, collection, userQuery)
+        graph = gbuilder.makeGraph(pipeline, [collection], collection, userQuery)
 
         self.assertEqual(len(graph), 2)
         taskDef = graph[0].taskDef

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -29,7 +29,7 @@ import unittest
 
 import lsst.utils.tests
 from lsst.daf.butler import (Registry, RegistryConfig, SchemaConfig,
-                             PreFlightCollectionsDef,
+                             DatasetOriginInfoDef,
                              StorageClass, StorageClassFactory)
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
@@ -173,7 +173,7 @@ class GraphBuilderTestCase(unittest.TestCase):
         pipeline = self._makePipeline()
         collection = ""
         userQuery = None
-        coll = PreFlightCollectionsDef([collection], collection)
+        coll = DatasetOriginInfoDef([collection], collection)
         graph = gbuilder.makeGraph(pipeline, coll, userQuery)
 
         self.assertEqual(len(graph), 2)
@@ -207,7 +207,7 @@ class GraphBuilderTestCase(unittest.TestCase):
         pipeline = self._makePipeline()
         collection = ""
         userQuery = "1 = 1"
-        coll = PreFlightCollectionsDef([collection], collection)
+        coll = DatasetOriginInfoDef([collection], collection)
         graph = gbuilder.makeGraph(pipeline, coll, userQuery)
 
         self.assertEqual(len(graph), 2)


### PR DESCRIPTION
Based on new pre-flight implementation `GraphBuilder` can now filter Quanta whose outputs already exist. CLI adds an option to enable this feature, by default existing output datasets cause exception.

Also added support for multiple input collections and pre-dataset type collection overrides.
