### PR TITLE
Always verify pipeline for cycle absence (DM-15801)

### DIFF
--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -23,9 +23,6 @@
 Module defining CmdLineFwk class and related methods.
 """
 
-from __future__ import print_function
-from builtins import object
-
 __all__ = ['CmdLineFwk']
 
 # -------------------------------
@@ -150,8 +147,8 @@ class CmdLineFwk(object):
             pipeBuilder = PipelineBuilder(self.taskFactory)
             pipeline = pipeBuilder.makePipeline(args)
         except Exception as exc:
-            print("Failed to build pipeline: {}".format(exc))
-            return 2
+            print("Failed to build pipeline: {}".format(exc), file=sys.stderr)
+            raise
 
         if args.save_pipeline:
             with open(args.save_pipeline, "wb") as pickleFile:
@@ -161,7 +158,8 @@ class CmdLineFwk(object):
             pipeline2dot(pipeline, args.pipeline_dot, self.taskFactory)
 
         if args.subcommand == "build":
-            # stop here
+            # stop here but process --show option first
+            self.showInfo(args.show, pipeline, None)
             return 0
 
         if args.qgraph:
@@ -432,7 +430,8 @@ class CmdLineFwk(object):
             elif showCommand == "tasks":
                 self._showTaskHierarchy(pipeline)
             elif showCommand == "graph":
-                self._showGraph(graph)
+                if graph:
+                    self._showGraph(graph)
             else:
                 print("Unknown value for show: %s (choose from '%s')" %
                       (what, "', '".join("pipeline config[=XXX] history=XXX tasks graph".split())),

--- a/python/lsst/pipe/supertask/examples/test1task.py
+++ b/python/lsst/pipe/supertask/examples/test1task.py
@@ -2,16 +2,20 @@
 """
 
 import lsst.log
+from lsst.daf.butler import StorageClass, StorageClassFactory
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
 _LOG = lsst.log.Log.getLogger(__name__)
 
 
+StorageClassFactory().registerStorageClass(StorageClass("example"))
+
+
 class Test1Config(PipelineTaskConfig):
     input = InputDatasetField(name="input",
                               units=["Camera", "Visit"],
-                              storageClass = "example",
+                              storageClass="example",
                               scalar=True,
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="output",

--- a/python/lsst/pipe/supertask/examples/test2task.py
+++ b/python/lsst/pipe/supertask/examples/test2task.py
@@ -2,10 +2,14 @@
 """
 
 import lsst.log
+from lsst.daf.butler import StorageClass, StorageClassFactory
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
 _LOG = lsst.log.Log.getLogger(__name__)
+
+
+StorageClassFactory().registerStorageClass(StorageClass("example"))
 
 
 class Test2Config(PipelineTaskConfig):

--- a/python/lsst/pipe/supertask/pipeTools.py
+++ b/python/lsst/pipe/supertask/pipeTools.py
@@ -221,6 +221,13 @@ def orderPipeline(pipeline, taskFactory=None):
 
     # if there is something left it means cycles
     if inputs:
-        raise PipelineDataCycleError("Pipeline has data cycles")
+        # format it in usable way
+        loops = []
+        for idx, inputNames in inputs.items():
+            taskName = pipeline[idx].label
+            outputNames = outputs[idx]
+            edge = "   {} -> {} -> {}".format(inputNames, taskName, outputNames)
+            loops.append(edge)
+        raise PipelineDataCycleError("Pipeline has data cycles:\n" + "\n".join(loops))
 
     return Pipeline(pipeline[idx] for idx in result)

--- a/python/lsst/pipe/supertask/pipelineBuilder.py
+++ b/python/lsst/pipe/supertask/pipelineBuilder.py
@@ -134,9 +134,11 @@ class PipelineBuilder(object):
 
                 self._configOverrideFile(pipeline, action.label, action.value)
 
-        # re-order pipeline if requested, this also checks for possible errors
+        # conditionally re-order pipeline if requested, but unconditionally
+        # check for possible errors
+        orderedPipeline = pipeTools.orderPipeline(pipeline, self.taskFactory)
         if args.order_pipeline:
-            pipeline = pipeTools.orderPipeline(pipeline, self.taskFactory)
+            pipeline = orderedPipeline
 
         return pipeline
 

--- a/tests/test_pipeTools.py
+++ b/tests/test_pipeTools.py
@@ -271,6 +271,11 @@ class PipelineToolsTestCase(unittest.TestCase):
             pipeline = pipeTools.orderPipeline(pipeline)
 
         # cycle in a graph should throw ValueError
+        pipeline = _makePipeline([("A", ("A", "B"), "task1")])
+        with self.assertRaises(pipeTools.PipelineDataCycleError):
+            pipeline = pipeTools.orderPipeline(pipeline)
+
+        # another kind of cycle in a graph
         pipeline = _makePipeline([("A", "B", "task1"),
                                   ("B", "C", "task2"),
                                   ("C", "D", "task3"),


### PR DESCRIPTION
Loops are only detected when we order pipeline and previously ordering
was only done when --order-pipeline option was set. Now we do checks
unconditionally. Added one more test for trivial loop.