### PR TITLE
DM-15686: Re-implement task run stage with gen3 middleware

### DIFF
--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -426,7 +426,14 @@ class CmdLineFwk(object):
 
         # Call task runQuantum() method. Any exception thrown here propagates
         # to multiprocessing module and to parent process.
-        return task.runQuantum(quantum, butler)
+        result = task.runQuantum(quantum, butler)
+
+        # save provenenace for current quantum
+        quantum._task = taskClass.__name__
+        quantum._run = butler.run
+        butler.registry.addQuantum(quantum)
+
+        return result
 
     def writeTaskInitOutputs(self, task, butler):
         """Write any datasets produced by initializing the given PipelineTask.

--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -391,6 +391,12 @@ class CmdLineFwk(object):
         butler : `Butler`
             data butler instance
         """
+        def _refComponents(refs):
+            """Return all dataset components recursively"""
+            for ref in refs:
+                yield ref
+                yield from _refComponents(ref.components.values())
+
         # main issue here is that the same DataRef can appear as input for
         # many quanta, to keep them unique we first collect tem into one
         # dict indexed by dataset id.
@@ -399,7 +405,7 @@ class CmdLineFwk(object):
         id2ref = {}
         for taskDef, quantum in graph.quanta():
             for refs in quantum.predictedInputs.values():
-                for ref in refs:
+                for ref in _refComponents(refs):
                     id2ref[ref.id] = ref
         if id2ref:
             # copy all collected refs to output collection

--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -374,15 +374,13 @@ class CmdLineFwk(object):
     def _updateOutputCollection(self, graph, butler):
         """Associate all existing datasets with output collection.
 
-        For every Quantum in a graph make sure that its existsing inputs are
+        For every Quantum in a graph make sure that its existing inputs are
         added to the Butler's output collection.
 
         For each quantum there are input and output DataRefs. With the
         current implementation of preflight output refs should not exist but
         input refs may belong to a different collection. We want all refs to
-        appear in output collection, so we have to "copy" those refs. Trouble
-        here is that there is no way to check now that ref is already in a
-        collection so we just assume that collection is initially empty.
+        appear in output collection, so we have to "copy" those refs.
 
         Parameters
         ----------
@@ -397,11 +395,9 @@ class CmdLineFwk(object):
                 yield ref
                 yield from _refComponents(ref.components.values())
 
-        # main issue here is that the same DataRef can appear as input for
-        # many quanta, to keep them unique we first collect tem into one
+        # Main issue here is that the same DataRef can appear as input for
+        # many quanta, to keep them unique we first collect them into one
         # dict indexed by dataset id.
-        collection = butler.run.collection
-        registry = butler.registry
         id2ref = {}
         for taskDef, quantum in graph.quanta():
             for refs in quantum.predictedInputs.values():
@@ -409,6 +405,8 @@ class CmdLineFwk(object):
                     id2ref[ref.id] = ref
         if id2ref:
             # copy all collected refs to output collection
+            collection = butler.run.collection
+            registry = butler.registry
             registry.associate(collection, id2ref.values())
 
     def _executePipelineTask(self, target):

--- a/python/lsst/pipe/supertask/examples/calexpToCoaddTask.py
+++ b/python/lsst/pipe/supertask/examples/calexpToCoaddTask.py
@@ -2,6 +2,7 @@
 """
 
 import lsst.log
+from lsst.afw.image import ExposureF
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
@@ -44,7 +45,7 @@ class CalexpToCoaddTask(PipelineTask):
                   self.getName(), calexpDataIds, coaddDataIds)
 
         # output data, scalar in this case
-        data = None
+        data = ExposureF(100, 100)
 
         # attribute name of struct is the same as a config field name
         return Struct(coadd=data)

--- a/python/lsst/pipe/supertask/examples/patchSkyMapTask.py
+++ b/python/lsst/pipe/supertask/examples/patchSkyMapTask.py
@@ -11,7 +11,7 @@ _LOG = lsst.log.Log.getLogger(__name__)
 class PatchSkyMapTaskConfig(PipelineTaskConfig):
     coadd = InputDatasetField(name="deepCoadd_calexp",
                               units=["SkyMap", "Tract", "Patch", "AbstractFilter"],
-                              storageClass="Exposure",
+                              storageClass="ExposureF",
                               scalar=True,
                               doc="DatasetType for the input image")
     inputCatalog = InputDatasetField(name="deepCoadd_mergeDet",
@@ -56,10 +56,10 @@ class PatchSkyMapTask(PipelineTask):
         """
 
         _LOG.info("executing %s: coadd=%s inputCatalog=%s",
-                  self.getName(), coadd, inputCatalog)
+                  self.getName(), coadd, type(inputCatalog))
 
-        # output data, scalar in this case
-        data = None
+        # output data, scalar in this case, just return input catalog without change
+        data = inputCatalog
 
         # attribute name of struct is the same as a config field name
         return Struct(outputCatalog=data)

--- a/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
+++ b/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
@@ -2,6 +2,7 @@
 """
 
 import lsst.log
+from lsst.afw.image import ExposureF
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
@@ -48,8 +49,8 @@ class RawToCalexpTask(PipelineTask):
 
         _LOG.info("executing %s: input=%s", self.getName(), input)
 
-        # result, scalar in this case
-        data = None
+        # result, scalar in this case, just create 100x100 image
+        data = ExposureF(100, 100)
 
         # attribute name of struct is the same as a config field name
         return Struct(output=data)

--- a/python/lsst/pipe/supertask/graph.py
+++ b/python/lsst/pipe/supertask/graph.py
@@ -91,3 +91,18 @@ class QuantumGraph(list):
     """
     def __init__(self, iterable=None):
         list.__init__(self, iterable or [])
+
+    def quanta(self):
+        """Iterator over quanta in a graph.
+
+        Yields
+        ------
+        taskDef : `TaskDef`
+            Task definition for a Quantum.
+        quantum : `Quantum`
+            Single quantum.
+        """
+        for taskNodes in self:
+            taskDef = taskNodes.taskDef
+            for quantum in taskNodes.quanta:
+                yield taskDef, quantum

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -299,6 +299,15 @@ class GraphBuilder(object):
                     dataRefs[_dataRefKey(dataRef)] = dataRef
                     _LOG.debug("add output dataRef: %s %s", dsType.name, dataRef)
 
+            # pre-flight does not fill dataset components, and graph users
+            # may need to know that, re-retrieve all input datasets to have
+            # their components properly filled.
+            for qinputs in taskQuantaInputs.values():
+                for dataRefs in qinputs.values():
+                    for key in dataRefs.keys():
+                        if dataRefs[key].id is not None:
+                            dataRefs[key] = self.registry.getDataset(dataRefs[key].id)
+
             # all nodes for this task
             quanta = []
             for qkey in taskQuantaInputs:


### PR DESCRIPTION
To run things we have to have all input DataRefs in the same collection
as output, added association of the all quantumGraph inputs with output
collection. Current assumption is that output collection is empty, will
have to extend implementation to support non-empty collections.

Updated example tasks to return data that can be saved to butler, with
that `stac` is now able to run complete chain on `ci_hsc` repo and write
something into that repo.