### PR TITLE
DM-16077: Fix multi-process setup for CmdLineFwk

### DIFF
--- a/python/lsst/pipe/supertask/examples/calexpToCoaddTask.py
+++ b/python/lsst/pipe/supertask/examples/calexpToCoaddTask.py
@@ -1,12 +1,13 @@
 """Simple example PipelineTask for testing purposes.
 """
 
-import lsst.log
+import logging
+
 from lsst.afw.image import ExposureF
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 
 class CalexpToCoaddTaskConfig(PipelineTaskConfig):

--- a/python/lsst/pipe/supertask/examples/patchSkyMapTask.py
+++ b/python/lsst/pipe/supertask/examples/patchSkyMapTask.py
@@ -1,11 +1,12 @@
 """Simple example PipelineTask for testing purposes.
 """
 
-import lsst.log
+import logging
+
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 
 class PatchSkyMapTaskConfig(PipelineTaskConfig):

--- a/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
+++ b/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
@@ -1,12 +1,13 @@
 """Simple example PipelineTask for testing purposes.
 """
 
-import lsst.log
+import logging
+
 from lsst.afw.image import ExposureF
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 
 class RawToCalexpTaskConfig(PipelineTaskConfig):

--- a/python/lsst/pipe/supertask/examples/test1task.py
+++ b/python/lsst/pipe/supertask/examples/test1task.py
@@ -1,12 +1,13 @@
 """Simple example PipelineTask for testing purposes.
 """
 
-import lsst.log
+import logging
+
 from lsst.daf.butler import StorageClass, StorageClassFactory
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 
 StorageClassFactory().registerStorageClass(StorageClass("example"))

--- a/python/lsst/pipe/supertask/examples/test2task.py
+++ b/python/lsst/pipe/supertask/examples/test2task.py
@@ -1,12 +1,13 @@
 """Simple example PipelineTask for testing purposes.
 """
 
-import lsst.log
+import logging
+
 from lsst.daf.butler import StorageClass, StorageClassFactory
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             InputDatasetField, OutputDatasetField)
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 
 StorageClassFactory().registerStorageClass(StorageClass("example"))

--- a/python/lsst/pipe/supertask/graphBuilder.py
+++ b/python/lsst/pipe/supertask/graphBuilder.py
@@ -31,20 +31,20 @@ __all__ = ['GraphBuilder']
 import copy
 from collections import namedtuple
 from itertools import chain
+import logging
 
 # -----------------------------
 #  Imports for other modules --
 # -----------------------------
 from .expr_parser.parserYacc import ParserYacc, ParserYaccError
 from .graph import QuantumGraphNodes, QuantumGraph
-import lsst.log as lsstLog
 from lsst.daf.butler import Quantum
 
 # ----------------------------------
 #  Local non-exported definitions --
 # ----------------------------------
 
-_LOG = lsstLog.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 # Tuple containing TaskDef, its input dataset types and output dataset types
 #

--- a/python/lsst/pipe/supertask/pipelineBuilder.py
+++ b/python/lsst/pipe/supertask/pipelineBuilder.py
@@ -31,6 +31,7 @@ __all__ = ['PipelineBuilder']
 # -------------------------------
 #  Imports of standard modules --
 # -------------------------------
+import logging
 import os
 import pickle
 
@@ -40,12 +41,13 @@ import pickle
 from .configOverrides import ConfigOverrides
 from .pipeline import Pipeline, TaskDef
 from . import pipeTools
-import lsst.log as lsstLog
 import lsst.utils
 
 # ----------------------------------
 #  Local non-exported definitions --
 # ----------------------------------
+
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 # ------------------------
 #  Exported definitions --
@@ -186,10 +188,10 @@ class PipelineBuilder(object):
                 os.path.join(obsPkgDir, "config", instrument, fileName),
             ):
                 if os.path.exists(filePath):
-                    lsstLog.info("Loading config overrride file %r", filePath)
+                    _LOG.info("Loading config overrride file %r", filePath)
                     overrides.addFileOverride(filePath)
                 else:
-                    lsstLog.debug("Config override file does not exist: %r", filePath)
+                    _LOG.debug("Config override file does not exist: %r", filePath)
 
             overrides.applyTo(config)
 

--- a/python/lsst/pipe/supertask/taskFactory.py
+++ b/python/lsst/pipe/supertask/taskFactory.py
@@ -1,16 +1,13 @@
 """Module which defines TaskFactory class and related methods.
 """
 
-from __future__ import absolute_import, division, print_function
-
 __all__ = ["TaskFactory"]
 
-from builtins import object
+import logging
 
 from .taskLoader import KIND_PIPELINETASK
-import lsst.log
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__.partition(".")[2])
 
 
 class TaskFactory(object):


### PR DESCRIPTION
Make sure that all objects that are passed from parent process to forked child can be correctly pickled. This needed following changes:
- make `_executePipelineTask()` method static and pass one extra argument to it
- make sure that Logger instance is not a member of any pickled classes/objects
- also needs couple of changes in `daf_butler` to make DatasetType and Butler instances work with pickle

I have replaced all logging to `lsst.log` with logging to `logging` to keep things more uniform. Also made logger names comply with LSST conventions (no "lsst." prefix).

With all these changes `-jN` seems to work fine with the example tasks.