### PR TITLE
Rename camera/sensor units (DM-16312)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/python/lsst/pipe/supertask/cmdLineParser.py
+++ b/python/lsst/pipe/supertask/cmdLineParser.py
@@ -355,9 +355,9 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
         subparser.add_argument("-p", "--pipeline", dest="pipeline",
                                help="Location of a serialized pipeline definition (pickle file).",
                                metavar="PATH")
-        subparser.add_argument("--camera-overrides", dest="camera_overrides",
+        subparser.add_argument("--instrument-overrides", dest="instrument_overrides",
                                default=False, action="store_true",
-                               help="Apply standard camera and package overrides "
+                               help="Apply standard instrument and package overrides "
                                "to configuration of new tasks.")
         subparser.add_argument("-t", "--task", metavar="TASK[:LABEL]",
                                dest="pipeline_actions", action='append', type=_ACTION_ADD_TASK,

--- a/python/lsst/pipe/supertask/examples/calexpToCoaddTask.py
+++ b/python/lsst/pipe/supertask/examples/calexpToCoaddTask.py
@@ -11,7 +11,7 @@ _LOG = lsst.log.Log.getLogger(__name__)
 
 class CalexpToCoaddTaskConfig(PipelineTaskConfig):
     calexp = InputDatasetField(name="calexp",
-                               units=["Camera", "Visit", "Sensor"],
+                               units=["Instrument", "Visit", "Detector"],
                                storageClass="ExposureF",
                                doc="DatasetType for the input image")
     coadd = OutputDatasetField(name="deepCoadd_calexp",

--- a/python/lsst/pipe/supertask/examples/make_example_qgraph.py
+++ b/python/lsst/pipe/supertask/examples/make_example_qgraph.py
@@ -151,7 +151,7 @@ def main():
 
 def _makeDSRefVisit(dstype, visitId):
         return DatasetRef(datasetType=dstype,
-                          dataId=dict(Camera="X",
+                          dataId=dict(Instrument="X",
                                       Visit=visitId,
                                       physical_filter='f',
                                       abstract_filter='f'))

--- a/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
+++ b/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
@@ -11,18 +11,18 @@ _LOG = lsst.log.Log.getLogger(__name__)
 
 class RawToCalexpTaskConfig(PipelineTaskConfig):
     input = InputDatasetField(name="raw",
-                              units=["Camera", "Exposure", "Sensor"],
+                              units=["Instrument", "Exposure", "Detector"],
                               storageClass="DecoratedImageU",
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="calexp",
-                                units=["Camera", "Visit", "Sensor"],
+                                units=["Instrument", "Visit", "Detector"],
                                 storageClass="ExposureF",
                                 scalar=True,
                                 doc="Output dataset type for this task")
 
     def setDefaults(self):
-        # set units of a quantum, this task uses per-visit-sensor quanta
-        self.quantum.units = ["Camera", "Visit", "Sensor"]
+        # set units of a quantum, this task uses per-visit-detector quanta
+        self.quantum.units = ["Instrument", "Visit", "Detector"]
 
 
 class RawToCalexpTask(PipelineTask):

--- a/python/lsst/pipe/supertask/examples/test1task.py
+++ b/python/lsst/pipe/supertask/examples/test1task.py
@@ -14,12 +14,12 @@ StorageClassFactory().registerStorageClass(StorageClass("example"))
 
 class Test1Config(PipelineTaskConfig):
     input = InputDatasetField(name="input",
-                              units=["Camera", "Visit"],
+                              units=["Instrument", "Visit"],
                               storageClass="example",
                               scalar=True,
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="output",
-                                units=["Camera", "Visit"],
+                                units=["Instrument", "Visit"],
                                 storageClass="example",
                                 scalar=True,
                                 doc="Output dataset type for this task")
@@ -27,7 +27,7 @@ class Test1Config(PipelineTaskConfig):
     def setDefaults(self):
         # set units of a quantum, this task uses per-visit quanta and it
         # expects datset units to be the same
-        self.quantum.units = ["Camera", "Visit"]
+        self.quantum.units = ["Instrument", "Visit"]
 
 
 class Test1Task(PipelineTask):

--- a/python/lsst/pipe/supertask/examples/test2task.py
+++ b/python/lsst/pipe/supertask/examples/test2task.py
@@ -14,7 +14,7 @@ StorageClassFactory().registerStorageClass(StorageClass("example"))
 
 class Test2Config(PipelineTaskConfig):
     input = InputDatasetField(name="input",
-                              units=["Camera", "Visit"],
+                              units=["Instrument", "Visit"],
                               storageClass="example",
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="output",
@@ -27,7 +27,7 @@ class Test2Config(PipelineTaskConfig):
         # this task combines all selected visits into a tract/patch, on
         # input it expects per-visit data, on output it produces per-patch.
         # Combining visits "destroys" Visit unit in a quantum.
-        self.quantum.units = ["Camera", "Tract", "Patch"]
+        self.quantum.units = ["Instrument", "Tract", "Patch"]
 
 
 class Test2Task(PipelineTask):

--- a/python/lsst/pipe/supertask/pipelineBuilder.py
+++ b/python/lsst/pipe/supertask/pipelineBuilder.py
@@ -83,12 +83,12 @@ class PipelineBuilder(object):
         Exceptions will be raised for any kind of error conditions.
         """
 
-        # need camera/package name to find overrides
+        # need instrument/package name to find overrides
         obsPkg = None
-        camera = None
-        if args.camera_overrides:
+        instrument = None
+        if args.instrument_overrides:
             # mapperClass = dafPersist.Butler.getMapperClass(args.input)
-            # camera = mapperClass.getCameraName()
+            # instrument = mapperClass.getCameraName()
             # obsPkg = mapperClass.getPackageName()
             pass
 
@@ -112,7 +112,7 @@ class PipelineBuilder(object):
 
             if action.action == "new_task":
 
-                self._newTask(pipeline, action.value, action.label, obsPkg, camera)
+                self._newTask(pipeline, action.value, action.label, obsPkg, instrument)
 
             elif action.action == "delete_task":
 
@@ -142,7 +142,7 @@ class PipelineBuilder(object):
 
         return pipeline
 
-    def _newTask(self, pipeline, taskName, label=None, obsPkg=None, camera=None):
+    def _newTask(self, pipeline, taskName, label=None, obsPkg=None, instrument=None):
         """Append new task to a pipeline.
 
         Parameters
@@ -159,8 +159,8 @@ class PipelineBuilder(object):
         obsPkg : `str`, optional
             Name of the package to look for task overrides, if None then
             overrides are not used.
-        camera : `str`, optional
-            Camera name, used for camera-specific overrides an only if
+        instrument : `str`, optional
+            Instrument name, used for instrument-specific overrides an only if
             `obsPkg` is not `None`.
         """
         # load task class, will throw on errors
@@ -175,7 +175,7 @@ class PipelineBuilder(object):
         # make config instance with defaults
         config = taskClass.ConfigClass()
 
-        # apply camera/package overrides
+        # apply instrument/package overrides
         if obsPkg:
             obsPkgDir = lsst.utils.getPackageDir(obsPkg)
             configName = taskClass._DefaultName
@@ -183,7 +183,7 @@ class PipelineBuilder(object):
             overrides = ConfigOverrides()
             for filePath in (
                 os.path.join(obsPkgDir, "config", fileName),
-                os.path.join(obsPkgDir, "config", camera, fileName),
+                os.path.join(obsPkgDir, "config", instrument, fileName),
             ):
                 if os.path.exists(filePath):
                     lsstLog.info("Loading config overrride file %r", filePath)

--- a/python/lsst/pipe/supertask/taskFactory.py
+++ b/python/lsst/pipe/supertask/taskFactory.py
@@ -69,7 +69,7 @@ class TaskFactory(object):
             configuration class to create new instance.
         overrides : `ConfigOverrides` or None
             Configuration overrides, this should contain all overrides to be
-            applied to a default task config, including camera-specific,
+            applied to a default task config, including instrument-specific,
             obs-package specific, and possibly command-line overrides.
         butler : `lsst.daf.butler.Butler` or None
             Butler instance used to obtain initialization inputs for

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -169,7 +169,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         show_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                         'order_pipeline', 'save_pipeline', 'pipeline_dot',
-                        'camera_overrides']
+                        'instrument_overrides']
         self.assertEqual(set(vars(args).keys()), set(global_options + show_options))
         self.assertEqual(args.subcommand, 'build')
 
@@ -179,7 +179,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         qgraph_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                           'order_pipeline', 'save_pipeline', 'pipeline_dot',
-                          'qgraph_dot', 'qgraph', 'save_qgraph', 'camera_overrides',
+                          'qgraph_dot', 'qgraph', 'save_qgraph', 'instrument_overrides',
                           'skip_existing']
         self.assertEqual(set(vars(args).keys()), set(global_options + qgraph_options))
         self.assertEqual(args.subcommand, 'qgraph')
@@ -190,7 +190,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         run_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                        'order_pipeline', 'save_pipeline', 'pipeline_dot',
-                       'qgraph_dot', 'qgraph', 'save_qgraph', 'camera_overrides',
+                       'qgraph_dot', 'qgraph', 'save_qgraph', 'instrument_overrides',
                        'skip_existing']
         self.assertEqual(set(vars(args).keys()), set(global_options + run_options))
         self.assertEqual(args.subcommand, 'run')
@@ -300,7 +300,7 @@ class CmdLineParserTestCase(unittest.TestCase):
                                                  PipelineAction("configfile", "label", "filename3")])
         self.assertIsNone(args.pipeline)
         self.assertIsNone(args.qgraph)
-        self.assertFalse(args.camera_overrides)
+        self.assertFalse(args.instrument_overrides)
         self.assertFalse(args.order_pipeline)
         self.assertIsNone(args.save_pipeline)
         self.assertIsNone(args.save_qgraph)
@@ -314,7 +314,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             run
             -p pipeline.pickle
             -g qgraph.pickle
-            --camera-overrides
+            --instrument-overrides
             -t task1
             -t task2:label2
             -t task3
@@ -347,7 +347,7 @@ class CmdLineParserTestCase(unittest.TestCase):
                                                  PipelineAction("config", "task4", "x=y")])
         self.assertEqual(args.pipeline, "pipeline.pickle")
         self.assertEqual(args.qgraph, "qgraph.pickle")
-        self.assertTrue(args.camera_overrides)
+        self.assertTrue(args.instrument_overrides)
         self.assertTrue(args.order_pipeline)
         self.assertEqual(args.save_pipeline, "newpipe.pickle")
         self.assertEqual(args.save_qgraph, "newqgraph.pickle")

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -179,21 +179,21 @@ class ParserLexTestCase(unittest.TestCase):
         """Test for more or less complete expression"""
         lexer = parserLex.ParserLex.make_lexer()
 
-        expr = ("((camera='HSC' AND sensor != 9) OR camera='CFHT') "
+        expr = ("((instrument='HSC' AND detector != 9) OR instrument='CFHT') "
                 "AND tract=8766 AND patch.cell_x > 5 AND "
                 "patch.cell_y < 4 AND abstract_filter='i'")
         tokens = (("LPAREN", "("),
                   ("LPAREN", "("),
-                  ("IDENTIFIER", "camera"),
+                  ("IDENTIFIER", "instrument"),
                   ("EQ", "="),
                   ("STRING_LITERAL", "HSC"),
                   ("AND", "AND"),
-                  ("IDENTIFIER", "sensor"),
+                  ("IDENTIFIER", "detector"),
                   ("NE", "!="),
                   ("NUMERIC_LITERAL", "9"),
                   ("RPAREN", ")"),
                   ("OR", "OR"),
-                  ("IDENTIFIER", "camera"),
+                  ("IDENTIFIER", "instrument"),
                   ("EQ", "="),
                   ("STRING_LITERAL", "CFHT"),
                   ("RPAREN", ")"),

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -223,7 +223,7 @@ class ParserLexTestCase(unittest.TestCase):
         """Test for more or less complete expression"""
         parser = parserYacc.ParserYacc()
 
-        expression = ("((camera='HSC' AND sensor != 9) OR camera='CFHT') "
+        expression = ("((instrument='HSC' AND detector != 9) OR instrument='CFHT') "
                       "AND tract=8766 AND patch.cell_x > 5 AND "
                       "patch.cell_y < 4 AND abstract_filter='i'")
 

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -39,12 +39,12 @@ from lsst.pipe.supertask.graphBuilder import _TaskDatasetTypes
 
 class OneToOneTaskConfig(PipelineTaskConfig):
     input = InputDatasetField(name="input",
-                              units=["Camera", "Visit"],
+                              units=["Instrument", "Visit"],
                               storageClass="example",
                               scalar=True,
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="output",
-                                units=["Camera", "Visit"],
+                                units=["Instrument", "Visit"],
                                 storageClass = "example",
                                 scalar=True,
                                 doc="Output dataset type for this task")
@@ -52,12 +52,12 @@ class OneToOneTaskConfig(PipelineTaskConfig):
     def setDefaults(self):
         # set units of a quantum, this task uses per-visit quanta and it
         # expects dataset units to be the same
-        self.quantum.units = ["Camera", "Visit"]
+        self.quantum.units = ["Instrument", "Visit"]
 
 
 class VisitToPatchTaskConfig(PipelineTaskConfig):
     input = InputDatasetField(name="input",
-                              units=["Camera", "Visit"],
+                              units=["Instrument", "Visit"],
                               storageClass="example",
                               scalar=False,
                               doc="Input dataset type for this task")

--- a/tests/test_pipeTools.py
+++ b/tests/test_pipeTools.py
@@ -82,7 +82,7 @@ def _makeConfig(inputName, outputName):
     else:
         config.output1.name = outputName
 
-    units = ["Visit", "Sensor"]
+    units = ["Visit", "Detector"]
     config.input1.units = units
     config.input2.units = units
     config.output1.units = units

--- a/tests/test_pipelineBuilder.py
+++ b/tests/test_pipelineBuilder.py
@@ -81,7 +81,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
         """
         # create a task with default label
         actions = [cmdLineParser._ACTION_ADD_TASK("TaskOne")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -93,7 +93,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
 
         # create a task, give it a label
         actions = [cmdLineParser._ACTION_ADD_TASK("TaskOne:label")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -106,7 +106,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
         # two different tasks
         actions = [cmdLineParser._ACTION_ADD_TASK("TaskOne"),
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -124,7 +124,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo"),
                    cmdLineParser._ACTION_ADD_TASK("TaskOne:label"),
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo:label2")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -144,7 +144,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
         """
         actions = [cmdLineParser._ACTION_ADD_TASK("TaskOne"),
                    cmdLineParser._ACTION_ADD_TASK("TaskOne")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -164,7 +164,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo"),
                    cmdLineParser._ACTION_ADD_TASK("TaskOne:label"),
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo:label2")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -199,7 +199,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo"),
                    cmdLineParser._ACTION_ADD_TASK("TaskOne:label"),
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo:label2")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -242,7 +242,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo"),
                    cmdLineParser._ACTION_ADD_TASK("TaskOne:label"),
                    cmdLineParser._ACTION_ADD_TASK("TaskTwo:label2")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -270,7 +270,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
         """
         # make simple pipeline
         actions = [cmdLineParser._ACTION_ADD_TASK("TaskOne:task")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)
@@ -293,7 +293,7 @@ class PipelineBuilderTestCase(unittest.TestCase):
         # make simple pipeline
         actions = [cmdLineParser._ACTION_ADD_TASK("TaskOne:task"),
                    cmdLineParser._ACTION_CONFIG("task.field=value")]
-        args = Namespace(camera_overrides=False,
+        args = Namespace(instrument_overrides=False,
                          pipeline=None,
                          pipeline_actions=actions,
                          order_pipeline=False)


### PR DESCRIPTION
Data units were renamed in daf_butler schema, Camera becomes Instrument
and Sensor becomes Detector. These names are used in few places in this
package too, follow that renaming in all usage of the unit names.