### PR TITLE
Pass correct argument to registry.associate (DM-16481)

### DIFF
--- a/python/lsst/pipe/supertask/cmdLineFwk.py
+++ b/python/lsst/pipe/supertask/cmdLineFwk.py
@@ -409,7 +409,7 @@ class CmdLineFwk(object):
             # copy all collected refs to output collection
             collection = butler.run.collection
             registry = butler.registry
-            registry.associate(collection, id2ref.values())
+            registry.associate(collection, list(id2ref.values()))
 
     @staticmethod
     def _executePipelineTask(target):


### PR DESCRIPTION
The method expects `list` as an argument and I was passing dict_values
to it, trivial fix by wrapping it into list.