### PR TITLE
Fix for running multi-task pipelines (DM-16831)

### DIFF
--- a/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
+++ b/python/lsst/pipe/supertask/examples/rawToCalexpTask.py
@@ -13,7 +13,7 @@ _LOG = logging.getLogger(__name__.partition(".")[2])
 class RawToCalexpTaskConfig(PipelineTaskConfig):
     input = InputDatasetField(name="raw",
                               dimensions=["Instrument", "Exposure", "Detector"],
-                              storageClass="DecoratedImageU",
+                              storageClass="ExposureU",
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="calexp",
                                 dimensions=["Instrument", "Visit", "Detector"],


### PR DESCRIPTION
Intermediate DatasetRefs in a QuantumGraph have their `id` set to None
and that confused cmdLineFwk. This patch makes sure that those
intermediate refs are handled properly.